### PR TITLE
First pass on docs

### DIFF
--- a/docs/Bomtrace2.md
+++ b/docs/Bomtrace2.md
@@ -1,14 +1,8 @@
 # Bomtrace2
 
-Bomtrace2 is version 2 of Bomtrace.
-Bomtrace2 improves performance over Bomtrace, has more command options/features, is more flexible and extensible, more tested for bugfixes, and more preferred to use than Bomtrace.
-Do the following to generate gitBOM docs for the HelloWorld program with Bomtrace2.
+Bomtrace2 uses the `strace` command to watch which programs are executed during a software build to find and record the input files, generating a GitBOM [artifact tree](https://gitbom.dev/glossary/artifact_tree/).
 
-```bash
-bomtrace2 <build command>
-# Generates the GitBOM metadata in the bomdir directory
-python3 bomsh_create_bom.py -r /tmp/bomsh_hook_raw_logfile -b bomdir
-```
+An example for generating an artifact tree for a C program, such as the HelloWorld program in `src`, is to run `bomtrace2 make`.
 
 Bomtrace2 works together with the `bomsh_hook2.py` script to record the raw info necessary to generate GitBOM docs. The raw info is recorded in `/tmp/bomsh_hook_raw_logfile` by default unless overriden with the `-r` option. For each process involved in building a complete program, the script records the checksums of the parsed input/output files and the shell command used to build the output file. An example for the HelloWorld program is:
 
@@ -37,7 +31,9 @@ The `-w watched_programs_file` argument is used to tell bomtrace2 to only record
 - An exact line of "---"
 - List of pre-exec mode only programs
 - An exact line of "==="
-- List of programs that can be detached upon execve syscall
+- List of ignored programs (`strace` will detach when executed)
 
-Lines starting with `#` are ignored. An example watched programs file is in `bin/bomtrace_watched_programs`
+Lines starting with `#` are ignored. An example watched programs file is in `bin/bomtrace_watched_programs`.
+
+Some programs, such as `./configure`, do not process additional input source files. Adding those programs to the ignored programs list can result in performance benefits.
 

--- a/docs/Bomtrace2.md
+++ b/docs/Bomtrace2.md
@@ -25,9 +25,13 @@ build_cmd: gcc -c -o hello.o hello.c
 
 After the software build is done, the `bomsh_create_bom.py` script is used to read the raw logfile, generate the hash tree, and create the GitBOM docs. The hash tree database is saved in `/tmp/bomsh_createbom_jsonfile` by default.
 
+## Config
+
+The `-c config_file` argument is used to read configuration options from file. A sample config file with documentation on each option is provided in `bin/bomtrace.conf`.
+
 ## Watched Programs
 
-The `-w watched_programs_file` option is used to tell bomtrace2 to only record commands for a limited set of programs. The watched programs file is formatted like:
+The `-w watched_programs_file` argument is used to tell bomtrace2 to only record commands for a limited set of programs. The watched programs file is formatted like:
 
 - List of watched programs.
 - An exact line of "---"

--- a/docs/Bomtrace2.md
+++ b/docs/Bomtrace2.md
@@ -1,0 +1,39 @@
+# Bomtrace2
+
+Bomtrace2 is version 2 of Bomtrace.
+Bomtrace2 improves performance over Bomtrace, has more command options/features, is more flexible and extensible, more tested for bugfixes, and more preferred to use than Bomtrace.
+Do the following to generate gitBOM docs for the HelloWorld program with Bomtrace2.
+
+```bash
+bomtrace2 <build command>
+# Generates the GitBOM metadata in the bomdir directory
+python3 bomsh_create_bom.py -r /tmp/bomsh_hook_raw_logfile -b bomdir
+```
+
+Bomtrace2 works together with the `bomsh_hook2.py` script to record the raw info necessary to generate GitBOM docs. The raw info is recorded in `/tmp/bomsh_hook_raw_logfile` by default unless overriden with the `-r` option. For each process involved in building a complete program, the script records the checksums of the parsed input/output files and the shell command used to build the output file. An example for the HelloWorld program is:
+
+```
+outfile: 6c7744ecf42790fb8073d0e822eb0a2b9b7c39e7 path: /home/bomsh/src/hello.o
+infile: 29039dc7dd32210e38e949fcf483ec8ce6f7a054 path: /home/bomsh/src/hello.c
+infile: c2ab78a2d4c20711295a501c61dd038bfa029934 path: /usr/include/stdc-predef.h
+infile: 739e08610d54f341cf14247ec38f254e1520e5b1 path: /usr/include/stdio.h
+...
+infile: 4f725e95ffa2663083b66a557b12751261cbcf05 path: /usr/include/bits/sys_errlist.h
+build_cmd: gcc -c -o hello.o hello.c
+==== End of raw info for this process
+```
+
+After the software build is done, the `bomsh_create_bom.py` script is used to read the raw logfile, generate the hash tree, and create the GitBOM docs. The hash tree database is saved in `/tmp/bomsh_createbom_jsonfile` by default.
+
+## Watched Programs
+
+The `-w watched_programs_file` option is used to tell bomtrace2 to only record commands for a limited set of programs. The watched programs file is formatted like:
+
+- List of watched programs.
+- An exact line of "---"
+- List of pre-exec mode only programs
+- An exact line of "==="
+- List of programs that can be detached upon execve syscall
+
+Lines starting with `#` are ignored. An example watched programs file is in `bin/bomtrace_watched_programs`
+

--- a/docs/Bomtrace2.md
+++ b/docs/Bomtrace2.md
@@ -4,6 +4,8 @@ Bomtrace2 uses the `strace` command to watch which programs are executed during 
 
 An example for generating an artifact tree for a C program, such as the HelloWorld program in `src`, is to run `bomtrace2 make`.
 
+The `/tmp` directory must contain the `bomsh_hook2.py` and `bomsh_create_bom.py` scripts.
+
 Bomtrace2 works together with the `bomsh_hook2.py` script to record the raw info necessary to generate GitBOM docs. The raw info is recorded in `/tmp/bomsh_hook_raw_logfile` by default unless overriden with the `-r` option. For each process involved in building a complete program, the script records the checksums of the parsed input/output files and the shell command used to build the output file. An example for the HelloWorld program is:
 
 ```
@@ -23,13 +25,17 @@ After the software build is done, the `bomsh_create_bom.py` script is used to re
 
 The `-c config_file` argument is used to read configuration options from file. A sample config file with documentation on each option is provided in `bin/bomtrace.conf`.
 
+## Logfile
+
+The `-o logfile` argument overrides the bomtrace logfile. It is `/tmp/bomsh_hook_strace_logfile` by default.
+
 ## Watched Programs
 
 The `-w watched_programs_file` argument is used to tell bomtrace2 to only record commands for a limited set of programs. The watched programs file is formatted like:
 
-- List of watched programs.
+- List of all watched programs
 - An exact line of "---"
-- List of pre-exec mode only programs
+- List of watched programs that overwrite the input file (such as `strip` and `objcopy`)
 - An exact line of "==="
 - List of ignored programs (`strace` will detach when executed)
 

--- a/docs/CVE Search Quickstart.md
+++ b/docs/CVE Search Quickstart.md
@@ -1,0 +1,18 @@
+# CVE Search Quick Start
+
+## Creating CVE Database
+
+```bash
+# Generates the CVE database in cvedb.json
+python3 bomsh_create_cve.py --use_git_tags --cveinfo_dir <directory with cveinfo yaml files> -j cvedb.json
+```
+
+Optionally add `--cve_check_dir <directory with cve-add and cve-fix files>`
+
+## Software Vulnerability CVE Search
+
+```bash
+# Results are stored in result.json
+python3 bomsh_search_cve.py -r <the treedb from generated gitbom> -d <cve database> -f <list of comma-separated files to search> -j result.json
+```
+

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -8,12 +8,12 @@
 - `head`
 - `xxd`
 
-For generating non-java boms:
+For generating C, Rust, and Go gitoids:
 - `ar`
 - `readelf`
 - `objcopy`
 
-For generating java boms:
+For generating Java gitoids:
 - Java
 - `zip`
 - `diff`
@@ -30,7 +30,7 @@ docker run -it --rm -v ${PWD}:/out bomsh
 
 ## Generate GitBOM Docs
 
-For C, Rust, and Go
+For C, Rust, and Go:
 
 ```bash
 bomtrace2 <build command>
@@ -38,7 +38,7 @@ bomtrace2 <build command>
 python3 bomsh_create_bom.py -r /tmp/bomsh_hook_raw_logfile -j treedb.json
 ```
 
-For Java
+For Java:
 
 ```bash
 # Generates the GitBOM metadata in treedb.json

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -1,0 +1,65 @@
+# Quick Start
+
+## Install Pre-Requisites
+
+- Python 3
+- Docker
+- `git`
+- `head`
+- `xxd`
+
+For generating non-java boms:
+- `ar`
+- `readelf`
+- `objcopy`
+
+For generating java boms:
+- Java
+- `zip`
+- `diff`
+
+## Compile Bombash and Bomtrace from Source
+
+```bash
+git clone https://github.com/git-bom/bomsh.git bomsh
+cd bomsh
+docker build -t bomsh .devcontainer
+# Copies the bombash/bomtrace/bomtrace2 binaries to the current working directory
+docker run -it --rm -v ${PWD}:/out bomsh
+```
+
+## Generate GitBOM Docs
+
+For C, Rust, and Go
+
+```bash
+bomtrace2 <build command>
+# Generates the GitBOM metadata in treedb.json
+python3 bomsh_create_bom.py -r /tmp/bomsh_hook_raw_logfile -j treedb.json
+```
+
+For Java
+
+```bash
+# Generates the GitBOM metadata in treedb.json
+python3 bomsh_create_bom_java.py -r <root directory of build workspace> -f <list of comma-separated jar files> -j treedb.json
+```
+
+## Creating CVE Database
+
+(TODO: describe how to create/find the cveinfo files needed)
+
+```bash
+# Generates the CVE database in cvedb.json
+python3 bomsh_create_cve.py --use_git_tags --cveinfo_dir <directory with cveinfo yaml files> -j cvedb.json
+```
+
+Optionally add `--cve_check_dir <directory with cve-add and cve-fix files>`
+
+## Software Vulnerability CVE Search
+
+```bash
+# Results are stored in result.json
+python3 bomsh_search_cve.py -r <the treedb from generated gitbom> -d <cve database> -f <list of comma-separated files to search> -j result.json
+```
+

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -33,6 +33,8 @@ docker run -it --rm -v ${PWD}:/out bomsh
 For C, Rust, and Go:
 
 ```bash
+cp scripts/bomsh_hook2.py /tmp
+cp scripts/bomsh_create_bom.py /tmp
 bomtrace2 <build command>
 # Generates the GitBOM metadata in treedb.json
 python3 bomsh_create_bom.py -r /tmp/bomsh_hook_raw_logfile -j treedb.json

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -45,21 +45,3 @@ For Java:
 python3 bomsh_create_bom_java.py -r <root directory of build workspace> -f <list of comma-separated jar files> -j treedb.json
 ```
 
-## Creating CVE Database
-
-(TODO: describe how to create/find the cveinfo files needed)
-
-```bash
-# Generates the CVE database in cvedb.json
-python3 bomsh_create_cve.py --use_git_tags --cveinfo_dir <directory with cveinfo yaml files> -j cvedb.json
-```
-
-Optionally add `--cve_check_dir <directory with cve-add and cve-fix files>`
-
-## Software Vulnerability CVE Search
-
-```bash
-# Results are stored in result.json
-python3 bomsh_search_cve.py -r <the treedb from generated gitbom> -d <cve database> -f <list of comma-separated files to search> -j result.json
-```
-


### PR DESCRIPTION
Added docs folder in repo containing easy-to-digest documentation meant for users unfamiliar with the software. Done in collaboration with @jeff-schutt.

1. Quickstart.md and CVE Search Quickstart.md contains the minimum requirements and instructions to generate GitBOM docs and search artifact tree for CVEs respectively, enabling linking to more documentation files as they are created
2. Bomtrace2.md summarizes bomtrace2 functionality, requirements, and format