### PR TITLE
handle empty __init__.py of Python package when computing hash

### DIFF
--- a/scripts/bomsh_art_tree.py
+++ b/scripts/bomsh_art_tree.py
@@ -1,4 +1,4 @@
-#! /bin/env python3
+#! /usr/bin/env python3
 # Copyright (c) 2022 Cisco and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/scripts/bomsh_create_bom.py
+++ b/scripts/bomsh_create_bom.py
@@ -1,4 +1,4 @@
-#! /bin/env python3
+#! /usr/bin/env python3
 # Copyright (c) 2022 Cisco and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/scripts/bomsh_create_bom_java.py
+++ b/scripts/bomsh_create_bom_java.py
@@ -1,4 +1,4 @@
-#! /bin/env python3
+#! /usr/bin/env python3
 # Copyright (c) 2022 Cisco and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/scripts/bomsh_create_cve.py
+++ b/scripts/bomsh_create_cve.py
@@ -1,4 +1,4 @@
-#! /bin/env python3
+#! /usr/bin/env python3
 # Copyright (c) 2022 Cisco and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/scripts/bomsh_dynlib.py
+++ b/scripts/bomsh_dynlib.py
@@ -1,4 +1,4 @@
-#! /bin/env python3
+#! /usr/bin/env python3
 # Copyright (c) 2022 Cisco and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -345,7 +345,7 @@ def get_all_shared_libraries():
     output = get_shell_cmd_output(cmd)
     verbose(output, LEVEL_2)
     if not output:
-        return libs
+        return all_libs
     libs_32bit, libs_64bit = all_libs["32bit"], all_libs["64bit"]
     lib_dir, lib_dir_changed = '', False
     lines = output.splitlines()
@@ -486,9 +486,9 @@ def rtd_parse_options():
     parser.add_argument('--hashtype',
                     help = "the hash type, like sha1/sha256, the default is sha1")
     parser.add_argument('-f', '--files',
-                    help = "comma-separated files to change embedded bom-id")
+                    help = "comma-separated files")
     parser.add_argument('-d', '--dirs',
-                    help = "comma-separated directories to search for files that need to change embedded bom-id")
+                    help = "comma-separated directories to search for files")
     parser.add_argument('--chroot_dir',
                     help = "the mock chroot directory")
     parser.add_argument("-v", "--verbose",

--- a/scripts/bomsh_hook.py
+++ b/scripts/bomsh_hook.py
@@ -1,4 +1,4 @@
-#! /bin/env python3
+#! /usr/bin/env python3
 # Copyright (c) 2022 Cisco and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/scripts/bomsh_hook2.py
+++ b/scripts/bomsh_hook2.py
@@ -1,4 +1,4 @@
-#! /bin/env python3
+#! /usr/bin/env python3
 # Copyright (c) 2022 Cisco and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/scripts/bomsh_index_debrepo.py
+++ b/scripts/bomsh_index_debrepo.py
@@ -1,4 +1,4 @@
-#! /bin/env python3
+#! /usr/bin/env python3
 # Copyright (c) 2022 Cisco and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/scripts/bomsh_index_ws.py
+++ b/scripts/bomsh_index_ws.py
@@ -1,4 +1,4 @@
-#! /bin/env python3
+#! /usr/bin/env python3
 # Copyright (c) 2022 Cisco and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/scripts/bomsh_index_yocto.py
+++ b/scripts/bomsh_index_yocto.py
@@ -1,4 +1,4 @@
-#! /bin/env python3
+#! /usr/bin/env python3
 # Copyright (c) 2022 Cisco and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/scripts/bomsh_pstree.py
+++ b/scripts/bomsh_pstree.py
@@ -1,4 +1,4 @@
-#! /bin/env python3
+#! /usr/bin/env python3
 # Copyright (c) 2023 Cisco and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/scripts/bomsh_rebuild_deb.py
+++ b/scripts/bomsh_rebuild_deb.py
@@ -1,4 +1,4 @@
-#! /bin/env python3
+#! /usr/bin/env python3
 # Copyright (c) 2023 Cisco and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -158,7 +158,8 @@ mmdebstrap_patch_text = """--- mmdebstrap.bak	2023-09-16 18:50:42.032552913 +000
 g_bomsh_dockerfile_str = '''
 
 # Set up debrebuild/mmdebstrap environment
-RUN apt-get update ; apt-get install -y git wget mmdebstrap devscripts python3-pycurl python3-yaml apt-utils ; \\
+RUN apt update ; export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true ; \\
+    apt install -y git wget mmdebstrap devscripts autoconf python3-pycurl python3-yaml apt-utils ; \\
     rm -rf /var/lib/apt/lists/* ;
 
 # Set up bomtrace2/bomsh environment

--- a/scripts/bomsh_rebuild_rpm.py
+++ b/scripts/bomsh_rebuild_rpm.py
@@ -1,4 +1,4 @@
-#! /bin/env python3
+#! /usr/bin/env python3
 # Copyright (c) 2023 Cisco and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/scripts/bomsh_sbom.py
+++ b/scripts/bomsh_sbom.py
@@ -1,4 +1,4 @@
-#! /bin/env python3
+#! /usr/bin/env python3
 # Copyright (c) 2023 Cisco and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/scripts/bomsh_search_cve.py
+++ b/scripts/bomsh_search_cve.py
@@ -1,4 +1,4 @@
-#! /bin/env python3
+#! /usr/bin/env python3
 # Copyright (c) 2022 Cisco and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
When a Python package has empty __init__.py file under its directory, this empty __init__.py is same for all such packages.
This creates an issue.

this commit will detect such empty __init__.py file and compute the hash of all the other .py files under that directory, to create a unique hash for the Python package.