### PR TITLE
Initial commit of bomtrace3 to improve performance

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,14 +10,21 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 WORKDIR /home/vscode
 RUN git clone https://github.com/strace/strace.git
 WORKDIR /home/vscode/strace
-RUN ./bootstrap && ./configure --enable-mpers=check && make
-COPY ./patches/bomtrace2.patch ./
+COPY ./patches/bomtrace2.patch ./patches/bomtrace3.patch ./
+COPY ./src/*.[ch] src/
 
 FROM strace as bomtrace2
+WORKDIR /home/vscode/strace
 RUN patch -p1 < bomtrace2.patch
-RUN make
+RUN ./bootstrap && ./configure --enable-mpers=check && make
+
+FROM strace as bomtrace3
+WORKDIR /home/vscode/strace
+RUN patch -p1 < bomtrace3.patch
+RUN ./bootstrap && ./configure --enable-mpers=check && make
 
 FROM base as copy
 WORKDIR /in
 COPY --from=bomtrace2 /home/vscode/strace/src/strace ./bomtrace2
+COPY --from=bomtrace3 /home/vscode/strace/src/strace ./bomtrace3
 CMD cp * /out

--- a/.devcontainer/patches/bomtrace3.patch
+++ b/.devcontainer/patches/bomtrace3.patch
@@ -1,0 +1,90 @@
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 44398cc2b..ff62c9a2f 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -63,6 +63,8 @@ libstrace_a_SOURCES =	\
+ 	bind.c		\
+ 	bjm.c		\
+ 	block.c		\
++	bomsh_config.c	\
++	bomsh_hook.c	\
+ 	bpf.c		\
+ 	bpf_attr.h	\
+ 	bpf_filter.c	\
+@@ -334,6 +336,8 @@ libstrace_a_SOURCES =	\
+ 	sendfile.c	\
+ 	sg_io_v3.c	\
+ 	sg_io_v4.c	\
++	sha1.c		\
++	sha256.c	\
+ 	shutdown.c	\
+ 	sigaltstack.c	\
+ 	sigevent.h	\
+diff --git a/src/execve.c b/src/execve.c
+index a9224543b..c09d2d1d7 100644
+--- a/src/execve.c
++++ b/src/execve.c
+@@ -13,6 +13,8 @@
+  */
+ 
+ #include "defs.h"
++#include "bomsh_config.h"
++#include "bomsh_hook.h"
+ 
+ static void
+ printargv(struct tcb *const tcp, kernel_ulong_t addr)
+@@ -96,6 +98,9 @@ printargc(struct tcb *const tcp, kernel_ulong_t addr)
+ static void
+ decode_execve(struct tcb *tcp, const unsigned int index)
+ {
++	/* record this command and run some prehook analysis */
++	(void)bomsh_record_command(tcp, index);
++
+ 	/* pathname */
+ 	printpath(tcp, tcp->u_arg[index + 0]);
+ 	tprint_arg_next();
+diff --git a/src/strace.c b/src/strace.c
+index 780e51e91..4067b11e2 100644
+--- a/src/strace.c
++++ b/src/strace.c
+@@ -43,6 +43,8 @@
+ #include "delay.h"
+ #include "wait.h"
+ #include "secontext.h"
++#include "bomsh_config.h"
++#include "bomsh_hook.h"
+ 
+ /* In some libc, these aren't declared. Do it ourself: */
+ extern char **environ;
+@@ -3988,6 +3990,8 @@ dispatch_event(const struct tcb_wait_data *wd)
+ 		break;
+ 
+ 	case TE_EXITED:
++		/* Run the hook program to do analysis */
++		bomsh_hook_program(current_tcp->pid);
+ 		print_exited(current_tcp, current_tcp->pid, status);
+ 		droptcb(current_tcp);
+ 		return true;
+@@ -4185,11 +4189,21 @@ terminate(void)
+ 	exit(exit_code);
+ }
+ 
++void strace_set_outfname(const char *fname)
++{
++	outfname = fname;
++}
++
++void strace_init(int argc, char *argv[]) {
++	init(argc, argv);
++}
++
+ int
+ main(int argc, char *argv[])
+ {
+ 	setlocale(LC_ALL, "");
+-	init(argc, argv);
++	bomsh_init(argc, argv);
++	//init(argc, argv);
+ 
+ 	exit_code = !nprocs;
+ 

--- a/.devcontainer/src/bomsh_config.c
+++ b/.devcontainer/src/bomsh_config.c
@@ -1,0 +1,732 @@
+/*
+ * Copyright (c) 2024, Cisco and/or its affiliates.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/omnibor/bomsh/blob/main/LICENSE
+ */
+
+#include "defs.h"
+#include <stdarg.h>
+#include <getopt.h>
+#include "config.h"
+#include "bomsh_config.h"
+#include "bomsh_hook.h"
+
+// read all data from the file FILEPATH and malloc the required buffer.
+// returned buffer needs to be freed by the caller
+// if READ_LEN is not NULL, then file size is written to READ_LEN
+char * bomsh_read_file(const char *filepath, long *read_len)
+{
+        char * buffer = 0;
+        long length;
+        FILE * f = fopen (filepath, "rb");
+
+        if (f) {
+                fseek(f, 0, SEEK_END);
+                length = ftell(f);
+                fseek (f, 0, SEEK_SET);
+		if (read_len) {
+			*read_len = length;
+		}
+		// allocate 1-byte more for NULL-terminated buffer
+                buffer = malloc(length+1);
+                if (buffer) {
+                        if (fread(buffer, 1, length, f) > 0) {
+                                buffer[length] = 0;
+                        }
+                        buffer[length] = 0;
+                }
+                fclose (f);
+        }
+        return buffer;
+}
+
+// global variables
+struct bomsh_configs g_bomsh_config;
+struct bomsh_globals g_bomsh_global;
+
+// a special mode to trace openat/close syscalls and record checksums of interested files.
+int bomsh_openat_mode = 0;
+int bomsh_openat_fd = -1;
+//static int bomsh_openat_fd_closed = 0;
+int bomsh_openat_fd_pid = -1;
+
+int bomsh_detach_on_pid = -5;
+
+// the debugging verbose level for bomtrace
+int bomsh_verbose = 0;
+
+// 100 programs should be sufficient for most software builds
+#define BOMSH_MAX_WATCHED_PROGRAMS 100
+static char *bomsh_watched_programs_str = NULL;
+static char **bomsh_pre_exec_programs = 0;
+static int bomsh_num_pre_exec_programs = 0;
+static char **bomsh_watched_programs = 0;
+static char **bomsh_detach_on_pid_programs = 0;
+static int bomsh_num_watched_programs = 0;
+static int bomsh_num_detach_on_pid_programs = 0;
+// umbrella pid feature to improve performance
+// only the child processes of umbrella process are recorded and run hookup
+static char **bomsh_umbrella_programs = 0;
+static int bomsh_num_umbrella_programs = 0;
+pid_t *bomsh_umbrella_pid_stack = 0;
+int bomsh_umbrella_pid_top = -1;
+
+// This list only contains the name (or basename) of the watched programs
+static char **bomsh_watched_program_names = 0;
+static int bomsh_num_watched_program_names = 0;
+static char **bomsh_pre_exec_program_names = 0;
+static int bomsh_num_pre_exec_program_names = 0;
+
+//#define BOMSH_PRINT_CONFIGS
+#ifdef BOMSH_PRINT_CONFIGS
+static void bomsh_print_programs(char **progs, int num_progs, const char *which_progs)
+{
+	if (!progs) {
+		return;
+	}
+	fprintf(stderr, "\n start printing %s programs:\n", which_progs);
+	for (int i=0; i<num_progs; i++) {
+		if (!progs[i]) {
+			break;
+		}
+		fprintf(stderr, "%s\n", progs[i]);
+	}
+}
+#endif
+
+#if 0
+// find the index of array element that equals path.
+// return -1 if the element cannot be found
+static int binary_search_program(char *array[], char *path, int low, int high) {
+	// Repeat until the pointers low and high meet each other
+	while (low <= high) {
+		int mid = low + (high - low) / 2;
+		if (strcmp(array[mid], path) == 0) {
+			return mid;
+		}
+		if (strcmp(array[mid], path) < 0)
+			low = mid + 1;
+		else
+			high = mid - 1;
+	}
+	return -1;
+}
+#endif
+
+// return the basename of a path, pointing to the rightmost part of the original string.
+char *
+bomsh_basename(char *path)
+{
+	char *s = strrchr(path, '/');
+	return s ? (s + 1) : path;
+}
+
+static int strcmp_comparator(const void *p, const void *q)
+{
+	return strcmp(* (char * const *) p, * (char * const *) q);
+}
+
+// check if a program is in the watched list.
+static int bomsh_is_program_inlist(char *prog, char **prog_list, int num_progs)
+{
+	return bsearch(&prog, prog_list, num_progs, sizeof(char *), strcmp_comparator) != NULL;
+	//return binary_search_program(prog_list, prog, 0, num_progs - 1) != -1;
+}
+
+// special programs that are usually named with some prefix
+static const char *bomsh_special_progs[] = {"gcc", "cc", "g++", "clang", "clang++", "strip", "objcopy", "ld", "ld.gold", "ld.bfd", "ar", "ranlib"} ;
+static const char *bomsh_special_pre_exec_progs[] = {"strip", "objcopy", "ranlib", "ar"} ;
+
+// check if a path ends with a specific suffix, progs array must be sorted
+static int bomsh_path_endswith(const char *path, const char **progs, int num_progs)
+{
+	char *string = strrchr(path, '-');
+	if (!string) {
+		return 0;
+	}
+	return bomsh_is_program_inlist(string + 1, (char **)progs, num_progs);
+}
+
+// on some platforms, strip/objcopy/ranlib tool is named with some prefix,
+// like x86_64-xr-linux-clang on Yocto,
+// or /usr/bin/x86_64-mageia-linux-gnu-gcc on Mageia.
+// Try to cover them as special watched program.
+static int
+bomsh_is_special_watched_pre_exec_program(const char *path)
+{
+	return bomsh_path_endswith(path, bomsh_special_pre_exec_progs,
+			sizeof(bomsh_special_pre_exec_progs)/sizeof(*bomsh_special_pre_exec_progs));
+}
+
+// check if a program is in the pre-exec mode program list.
+int bomsh_is_pre_exec_program(char *prog)
+{
+	if (!bomsh_pre_exec_programs) {  // there is no any watched program, so matching any program
+		return 1;
+	}
+	if (g_bomsh_config.strict_prog_path) {
+		return bomsh_is_program_inlist(prog, bomsh_pre_exec_programs, bomsh_num_pre_exec_programs);
+	} else {
+		char *name = bomsh_basename(prog);
+		return bomsh_is_program_inlist(name, bomsh_pre_exec_program_names, bomsh_num_pre_exec_program_names)
+			|| bomsh_is_special_watched_pre_exec_program(prog);
+	}
+}
+
+// on some platforms, gcc compiler or ld tool is installed to non-standard location,
+// like /usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld on OpenSUSE,
+// or /usr/bin/x86_64-mageia-linux-gnu-gcc on Mageia.
+// or different versions of clang compilers.
+// Try to cover them as special watched program.
+static int
+bomsh_is_special_watched_program(const char *path)
+{
+	/*int len = strlen(path);
+	if (len < 4) return 0;
+	if (path[len - 3] == '/' && path[len - 2] == 'l' && path[len - 1] == 'd') return 1;
+	if (strcmp(path + len - 3, "-cc") == 0 || strcmp(path + len - 3, "/cc") == 0) return 1;
+	if (strcmp(path + len - 4, "-gcc") == 0 || strcmp(path + len - 4, "/gcc") == 0) return 1;*/
+	if (strncmp(bomsh_basename((char *)path), "clang", 5) == 0) return 1;
+	return bomsh_path_endswith(path, bomsh_special_progs, sizeof(bomsh_special_progs)/sizeof(*bomsh_special_progs));
+}
+
+// check if a program is in the watched list.
+int bomsh_is_watched_program(char *prog)
+{
+	if (!bomsh_watched_programs) {  // there is no any watched program, so matching any program
+		return 1;
+	}
+	if (g_bomsh_config.strict_prog_path) {
+		return bomsh_is_program_inlist(prog, bomsh_watched_programs, bomsh_num_watched_programs);
+	} else {
+		char *name = bomsh_basename(prog);
+		return bomsh_is_program_inlist(name, bomsh_watched_program_names, bomsh_num_watched_program_names)
+			|| bomsh_is_special_watched_program(prog);
+	}
+}
+
+// check if a program is in the detach_on_pid list.
+int bomsh_is_detach_on_pid_program(char *prog)
+{
+	if (!bomsh_detach_on_pid_programs) {  // there is no any detach_on_pid program, so matching none.
+		return 0;
+	}
+	return bomsh_is_program_inlist(prog, bomsh_detach_on_pid_programs, bomsh_num_detach_on_pid_programs);
+}
+
+// check if a program is in the umbrella list.
+int bomsh_is_umbrella_program(char *prog)
+{
+	if (!bomsh_umbrella_programs) {  // there is no any umbrella program, so matching none.
+		return 0;
+	}
+	return bomsh_is_program_inlist(prog, bomsh_umbrella_programs, bomsh_num_umbrella_programs);
+}
+
+// Extract list of programs from the string and save them into an array of pointers.
+// The programs_str contains the list of programs separated by newline character.
+static char **
+bomsh_get_watched_programs(char *programs_str, int *num_programs)
+{
+        char ** ret_watched_progs;
+        char * watched_progs[BOMSH_MAX_WATCHED_PROGRAMS];
+	char delim[] = "\n";
+
+	int i = 0;
+	char *ptr = strtok(programs_str, delim);
+	while(ptr != NULL)
+	{
+		if (strlen(ptr) > 0 && ptr[0] != '#') {
+			watched_progs[i] = ptr; i++;
+			if (i >= BOMSH_MAX_WATCHED_PROGRAMS) {
+				fprintf(stderr, "Maximum reached, only the first %d programs are read\n", BOMSH_MAX_WATCHED_PROGRAMS);
+				goto ret_here;
+			}
+		}
+		ptr = strtok(NULL, delim);
+	}
+	if (i == 0) {  // need at least one watched program
+		//fprintf(stderr, "No watched program is read\n");
+		return NULL;
+	}
+ret_here:
+	ret_watched_progs = (char **)malloc( i * sizeof(char *) );
+	//fprintf(stderr, "progs: %p num: %d\n", ret_watched_progs, i);
+	if (!ret_watched_progs) {
+		return NULL;
+	}
+	*num_programs = i;
+	for(i=0; i < *num_programs; i++) {
+		ret_watched_progs[i] = watched_progs[i];
+	}
+	// sort the array for binary search
+	qsort(ret_watched_progs, i, sizeof(char *), strcmp_comparator);
+	return ret_watched_progs;
+}
+
+/*
+ * Each line is a program to watch, there should be no leading or trailing spaces.
+ * Empty line or line starting with '#' character will be ignored.
+ * pre-exec mode programs are also in this file, separated by an exact line of "---"
+ * detach_on_pid programs are also in this file, separated by an exact line of "==="
+ * umbrella programs are also in this file, separated by an exact line of "+++"
+ */
+static char **
+bomsh_read_watched_programs(char *prog_file)
+{
+	bomsh_watched_programs_str = bomsh_read_file(prog_file, NULL);
+	if (!bomsh_watched_programs_str) {
+		fprintf(stderr, "Cannot open the watched program list file\n");
+		return NULL;
+	}
+	// must search sep_line in reversed order, since we set NULL character
+	char *plus_sep_line = strstr(bomsh_watched_programs_str, "+++");
+        if (plus_sep_line) {
+		*plus_sep_line = 0;
+		plus_sep_line += 4;  // move to start of umbrella program list
+	}
+	char *equal_sep_line = strstr(bomsh_watched_programs_str, "===");
+        if (equal_sep_line) {
+		*equal_sep_line = 0;
+		equal_sep_line += 4;  // move to start of detach-on-pid program list
+	}
+	char *minus_sep_line = strstr(bomsh_watched_programs_str, "---");
+        if (minus_sep_line) {
+		*minus_sep_line = 0;
+		minus_sep_line += 4;  // move to start of pre-exec program list
+	}
+	char ** watched_progs;
+	watched_progs = bomsh_get_watched_programs(bomsh_watched_programs_str, &bomsh_num_watched_programs);
+	if (minus_sep_line) {
+		bomsh_pre_exec_programs = bomsh_get_watched_programs(minus_sep_line, &bomsh_num_pre_exec_programs);
+	}
+	if (equal_sep_line) {
+		bomsh_detach_on_pid_programs = bomsh_get_watched_programs(equal_sep_line, &bomsh_num_detach_on_pid_programs);
+	}
+	if (plus_sep_line) {
+		bomsh_umbrella_programs = bomsh_get_watched_programs(plus_sep_line, &bomsh_num_umbrella_programs);
+		if (bomsh_umbrella_programs) {
+			bomsh_umbrella_pid_stack = malloc(sizeof(pid_t) * 64);
+			//fprintf(stderr, "alloc umbrella_stack: %p pid_top: %d\n", bomsh_umbrella_pid_stack, bomsh_umbrella_pid_top);
+			if (!bomsh_umbrella_pid_stack) {
+				fprintf(stderr, "Failed to alloc memory.");
+			}
+		}
+	}
+
+	if (!watched_progs && !bomsh_detach_on_pid_programs && !bomsh_pre_exec_programs && !bomsh_umbrella_programs) {
+		// only if there is no any programs, then we can delete this string
+		free(bomsh_watched_programs_str);
+		return NULL;
+	}
+#ifdef BOMSH_PRINT_CONFIGS
+if (bomsh_verbose > 2) {
+	bomsh_print_programs(watched_progs, bomsh_num_watched_programs, "watched_progs");
+	bomsh_print_programs(bomsh_pre_exec_programs, bomsh_num_pre_exec_programs, "pre_exec_progs");
+	bomsh_print_programs(bomsh_detach_on_pid_programs, bomsh_num_detach_on_pid_programs, "detach_on_pid");
+	bomsh_print_programs(bomsh_umbrella_programs, bomsh_num_umbrella_programs, "umbrella_progs");
+}
+#endif
+	// bomsh_watched_programs_str contains strings that are referenced by pointers of some progs
+	// thus its memory must not be freed.
+	return watched_progs;
+}
+
+static void
+bomsh_log_configs(int level)
+{
+	bomsh_log_string(level, "\n---Printing bomtrace configs:\n");
+	bomsh_log_printf(level, "hook_script_file: %s\n", g_bomsh_config.hook_script_file);
+	bomsh_log_printf(level, "hook_script_cmdopt: %s\n", g_bomsh_config.hook_script_cmdopt);
+	bomsh_log_printf(level, "shell_cmd_file: %s\n", g_bomsh_config.shell_cmd_file);
+	bomsh_log_printf(level, "tmpdir: %s\n", g_bomsh_config.tmpdir);
+	bomsh_log_printf(level, "logfile: %s\n", g_bomsh_config.logfile);
+	bomsh_log_printf(level, "raw_logfile: %s\n", g_bomsh_config.raw_logfile);
+	bomsh_log_printf(level, "syscalls: %s\n", g_bomsh_config.syscalls);
+	bomsh_log_printf(level, "hash algorithm: %d\n", g_bomsh_config.hash_alg);
+	//bomsh_log_printf(level, "metadata to record: %d\n", g_bomsh_config.metadata_to_record);
+	bomsh_log_printf(level, "generate depfile: %d\n", g_bomsh_config.generate_depfile);
+	bomsh_log_printf(level, "handle conftest: %d\n", g_bomsh_config.handle_conftest);
+	bomsh_log_printf(level, "skip_checking_prog_access: %d\n", g_bomsh_config.skip_checking_prog_access);
+	bomsh_log_printf(level, "strict_prog_path: %d\n", g_bomsh_config.strict_prog_path);
+	bomsh_log_string(level, "---End of printing bomtrace configs.\n");
+}
+
+#ifdef BOMSH_PRINT_CONFIGS
+static void
+bomsh_print_configs(void)
+{
+	fprintf(stderr, "\nPrinting bomtrace configs:\n");
+	fprintf(stderr, "hook_script_file: %s\n", g_bomsh_config.hook_script_file);
+	fprintf(stderr, "hook_script_cmdopt: %s\n", g_bomsh_config.hook_script_cmdopt);
+	fprintf(stderr, "shell_cmd_file: %s\n", g_bomsh_config.shell_cmd_file);
+	fprintf(stderr, "tmpdir: %s\n", g_bomsh_config.tmpdir);
+	fprintf(stderr, "logfile: %s\n", g_bomsh_config.logfile);
+	fprintf(stderr, "raw_logfile: %s\n", g_bomsh_config.raw_logfile);
+	fprintf(stderr, "syscalls: %s\n", g_bomsh_config.syscalls);
+	fprintf(stderr, "hash algorithm: %d\n", g_bomsh_config.hash_alg);
+	//fprintf(stderr, "metadata to record: %d\n", g_bomsh_config.metadata_to_record);
+	fprintf(stderr, "generate depfile: %d\n", g_bomsh_config.generate_depfile);
+	fprintf(stderr, "handle conftest: %d\n", g_bomsh_config.handle_conftest);
+	fprintf(stderr, "skip_checking_prog_access: %d\n", g_bomsh_config.skip_checking_prog_access);
+	fprintf(stderr, "strict_prog_path: %d\n", g_bomsh_config.strict_prog_path);
+}
+#endif
+
+// Create a sorted array of pointers to the basename of watched programs.
+static char **
+create_watched_program_names(char **watched_programs, int num_watched_programs)
+{
+	int i;
+	if (num_watched_programs == 0) {
+		return NULL;
+	}
+	char ** ret_watched_progs = (char **)malloc( num_watched_programs * sizeof(char *) );
+	for (i=0; i<num_watched_programs; i++) {
+		ret_watched_progs[i] = bomsh_basename(watched_programs[i]);
+	}
+	// sort the array for binary search
+	qsort(ret_watched_progs, num_watched_programs, sizeof(char *), strcmp_comparator);
+	return ret_watched_progs;
+}
+
+// read the configuration key/value from the current key=value line
+static void
+bomsh_read_value_for_keys(char *line_start, char *value_equal, char *value_newline)
+{
+	char *hash_alg_str = NULL;
+	char *generate_depfile_str = NULL;
+	char *handle_conftest_str = NULL;
+	char *skip_checking_prog_access_str = NULL;
+	char *strict_prog_path_str = NULL;
+	static const char *bomsh_config_keys[] = {"hook_script_file", "hook_script_cmdopt", "shell_cmd_file",
+						"tmpdir", "logfile", "raw_logfile", "syscalls",
+						"hash_alg", "generate_depfile", "handle_conftest",
+						"skip_checking_prog_access", "strict_prog_path"};
+	char ** bomsh_config_fields[] = {
+		&g_bomsh_config.hook_script_file,
+		&g_bomsh_config.hook_script_cmdopt,
+		&g_bomsh_config.shell_cmd_file,
+		&g_bomsh_config.tmpdir,
+		&g_bomsh_config.logfile,
+		&g_bomsh_config.raw_logfile,
+		&g_bomsh_config.syscalls,
+		&hash_alg_str,
+		&generate_depfile_str,
+		&handle_conftest_str,
+		&skip_checking_prog_access_str,
+		&strict_prog_path_str
+	};
+	int num_keys = sizeof(bomsh_config_keys)/sizeof(char *);
+        const char *key; unsigned long len;
+	for (int i=0; i < num_keys; i++) {
+		key = bomsh_config_keys[i];
+		if (strncmp(key, line_start, strlen(key)) == 0) {
+			len = value_newline - value_equal ;  // this len includes NULL terminating character
+			if (len >= PATH_MAX - sizeof(int) * 3) {
+				continue;
+			}
+			char *buf = malloc(len);
+			if (!buf) {
+				fprintf(stderr, "Failed to alloc memory.");
+				return;
+			}
+			strncpy(buf, value_equal + 1, len - 1);
+			buf[len - 1] = 0;
+			if (*(bomsh_config_fields[i])) {
+				free(*(bomsh_config_fields[i]));
+			}
+			*(bomsh_config_fields[i]) = buf;
+			//fprintf(stderr, "Read key: %s value: %s\n", key, buf);
+			break;
+		}
+	}
+	if (hash_alg_str) {
+		g_bomsh_config.hash_alg = atoi(hash_alg_str);
+		//g_bomsh_config.hash_alg = atoi(hash_alg_str) & 0x3;
+		free(hash_alg_str);
+	}
+	if (generate_depfile_str) {
+		g_bomsh_config.generate_depfile = atoi(generate_depfile_str) & 0x3;
+		free(generate_depfile_str);
+	}
+	if (handle_conftest_str) {
+		g_bomsh_config.handle_conftest = atoi(handle_conftest_str);
+		free(handle_conftest_str);
+	}
+	if (skip_checking_prog_access_str) {
+		if (strcmp(skip_checking_prog_access_str, "1") == 0) {
+			g_bomsh_config.skip_checking_prog_access = 1;
+		} else {
+			g_bomsh_config.skip_checking_prog_access = 0;
+		}
+		free(skip_checking_prog_access_str);
+	}
+	if (strict_prog_path_str) {
+		if (strcmp(strict_prog_path_str, "1") == 0) {
+			g_bomsh_config.strict_prog_path = 1;
+		} else {
+			g_bomsh_config.strict_prog_path = 0;
+		}
+		free(strict_prog_path_str);
+	}
+}
+
+// scan the config file and read all the configuration keys and values
+static void
+bomsh_read_configs(char *config_file)
+{
+	char *bomsh_configs_str = bomsh_read_file(config_file, NULL);
+	if (!bomsh_configs_str) {
+		fprintf(stderr, "Cannot open the config file %s\n", config_file);
+		return;
+	}
+        char *p = bomsh_configs_str;  // pointing to current character
+        char *q = bomsh_configs_str;  // pointing to the beginning of current line
+        char *r = NULL;  // pointing to the first '=' character in the line
+        while (*p) {
+		if (*p == '=' && !r) {  // move to the first '=' character in the line
+			r = p;
+		}
+		else if (*p == '\n') {
+			if (*q != '#' && *q != '\n' && r > q && r < p) {  // found one valid line of key=value
+				bomsh_read_value_for_keys(q, r, p);
+			}
+			q = p + 1;  // move to the beginning of next line
+			r = NULL;  // set to NULL for next line
+		}
+		p++;
+	}
+}
+
+// initialize 3 log files for later use
+static int bomsh_init_logfiles(void)
+{
+	char buf[PATH_MAX];
+	if (!g_bomsh_config.tmpdir) {
+		g_bomsh_config.tmpdir = (char *)"/tmp";
+	}
+	// first one is for debug purpose
+	if (g_bomsh_config.logfile && g_bomsh_config.logfile[0] == 0) {
+		// logfile="", if user configures so, then there will be no debug logfile at all.
+	} else {
+		if (!g_bomsh_config.logfile) {
+			sprintf(buf, "%s/bomsh_hook_bomtrace_logfile", g_bomsh_config.tmpdir);
+			g_bomsh_config.logfile = strdup(buf);
+			//g_bomsh_config.logfile = (char *)"/tmp/bomsh_hook_bomtrace_logfile";
+		}
+		g_bomsh_global.logfile = fopen(g_bomsh_config.logfile, "a");
+		if (!g_bomsh_global.logfile) {
+			fprintf(stderr, "Failed to open logfile: %s\n", g_bomsh_config.logfile);
+			return -1;
+		}
+	}
+	if (g_bomsh_config.hash_alg < 0) {
+		// negative value means NO_HASH computation at all.
+		return 0;
+	}
+	// The other two are for SHA1/SHA256 hash logging of ADF (Artifact Dependency Fragment)
+	if (!g_bomsh_config.raw_logfile) {
+		sprintf(buf, "%s/bomsh_hook_raw_logfile", g_bomsh_config.tmpdir);
+		g_bomsh_config.raw_logfile = strdup(buf);
+		//g_bomsh_config.raw_logfile = (char *)"/tmp/bomsh_hook_raw_logfile";
+	}
+	if (g_bomsh_config.hash_alg == 3) {
+		sprintf(buf, "%s.sha1", g_bomsh_config.raw_logfile);
+		g_bomsh_global.raw_logfile = fopen(buf, "a");
+		bomsh_log_printf(0, "Logging SHA1 to %s\n", buf);
+		sprintf(buf, "%s.sha256", g_bomsh_config.raw_logfile);
+		g_bomsh_global.raw_logfile2 = fopen(buf, "a");
+		bomsh_log_printf(0, "Logging SHA256 to %s\n", buf);
+	} else if (g_bomsh_config.hash_alg == 2) {
+		sprintf(buf, "%s.sha256", g_bomsh_config.raw_logfile);
+		g_bomsh_global.raw_logfile = fopen(buf, "a");
+		bomsh_log_printf(0, "Logging SHA256 to %s\n", buf);
+	} else {
+		sprintf(buf, "%s.sha1", g_bomsh_config.raw_logfile);
+		g_bomsh_global.raw_logfile = fopen(buf, "a");
+		bomsh_log_printf(0, "Logging SHA1 to %s\n", buf);
+	}
+	return 0;
+}
+
+static void
+bomsh_usage(void)
+{
+	printf("Usage: bomtrace3 -h [-o FILE] [-c FILE] [-v level] [-w FILE] PROG [ARGS]\n");
+	exit(0);
+}
+
+//static void ATTRIBUTE_NOINLINE
+void bomsh_init(int argc, char *argv[])
+{
+	int i, c;
+	static const char bomsh_optstring[] = "+hc:o:v:w:";
+
+	static const struct option bomsh_longopts[] = {
+		{ "help",		no_argument,	   0, 'h' },
+		{ "config",		required_argument, 0, 'c' },
+		{ "output",		required_argument, 0, 'o' },
+		{ "verbose",		required_argument, 0, 'v' },
+		{ "watch",		required_argument, 0, 'w' },
+		{ 0, 0, 0, 0 }
+	};
+	char *argv0 = argv[0];
+	static const char *bomsh_argv1[] = {"-f", "-s99999", "-e", "trace=execve", "-qqq"};
+	static const char *bomsh_argv2[] = {"-f", "-s99999", "-e", "trace=execve", "--seccomp-bpf", "-qqq"};
+	const char **bomsh_argv;
+	int bomsh_argc;
+	strace_set_outfname("/dev/null");
+	memset(&g_bomsh_config, 0, sizeof(g_bomsh_config));
+
+	while ((c = getopt_long(argc, argv, bomsh_optstring, bomsh_longopts, NULL)) != EOF) {
+
+		switch (c) {
+		case 'h':
+			bomsh_usage();
+			break;
+		case 'o':
+			strace_set_outfname(optarg);
+			//fprintf(stderr, "set strace outfname: %s\n", optarg);
+			break;
+		case 'c':
+			// read the configuration items from the file
+			bomsh_read_configs(optarg);
+#ifdef BOMSH_PRINT_CONFIGS
+			fprintf(stderr, "reading bomsh config file: %s\n", optarg);
+			bomsh_print_configs();
+#endif
+			break;
+		case 'v':
+			// set the verbose debugging level
+			bomsh_verbose = atoi(optarg);
+			break;
+		case 'w':
+			// read the list of programs from the file
+			bomsh_watched_programs = bomsh_read_watched_programs(optarg);
+			// sort the bomsh_special_progs array for binary search
+			qsort(bomsh_special_progs, sizeof(bomsh_special_progs)/sizeof(*bomsh_special_progs), sizeof(char *), strcmp_comparator);
+			qsort(bomsh_special_pre_exec_progs, sizeof(bomsh_special_pre_exec_progs)/sizeof(*bomsh_special_pre_exec_progs), sizeof(char *), strcmp_comparator);
+			break;
+		default:
+			error_msg_and_help(NULL);
+			break;
+		}
+	}
+
+	if (bomsh_init_logfiles() < 0) {
+		exit(0);
+	}
+	bomsh_log_printf(0, "successful with logfiles, verbose level: %d\n", bomsh_verbose);
+	bomsh_log_configs(8);
+
+	argv += optind;
+	argc -= optind;
+	if (argc <= 0) {
+		error_msg_and_help("must have PROG [ARGS]");
+	}
+	if (!g_bomsh_config.strict_prog_path) {
+		bomsh_watched_program_names = create_watched_program_names(bomsh_watched_programs, bomsh_num_watched_programs);
+		bomsh_num_watched_program_names = bomsh_num_watched_programs;
+		bomsh_pre_exec_program_names = create_watched_program_names(bomsh_pre_exec_programs, bomsh_num_pre_exec_programs);
+		bomsh_num_pre_exec_program_names = bomsh_num_pre_exec_programs;
+#ifdef BOMSH_PRINT_CONFIGS
+		bomsh_print_programs(bomsh_watched_program_names, bomsh_num_watched_program_names, "watched_prog_names");
+		bomsh_print_programs(bomsh_pre_exec_program_names, bomsh_num_pre_exec_program_names, "pre_exec_prog_names");
+		bomsh_print_configs();
+#endif
+	}
+	if (bomsh_detach_on_pid_programs) {
+		// cannot use both detach and --seccomp-bpf due to limitation
+		bomsh_argv = bomsh_argv1;
+		bomsh_argc = sizeof(bomsh_argv1)/sizeof(char *);
+	} else {
+		bomsh_argv = bomsh_argv2;
+		bomsh_argc = sizeof(bomsh_argv2)/sizeof(char *);
+	}
+	char * trace_syscalls = NULL;
+	if (g_bomsh_config.syscalls) {
+		trace_syscalls = (char *) malloc(strlen(bomsh_argv[3]) + strlen(g_bomsh_config.syscalls) + 2);
+		if (!trace_syscalls) {
+			fprintf(stderr, "Failed to alloc memory.");
+			exit(0);
+		}
+		sprintf(trace_syscalls, "%s,%s", bomsh_argv[3], g_bomsh_config.syscalls);
+		bomsh_argv[3] = trace_syscalls;  // more syscalls will be traced
+		if (strncmp(g_bomsh_config.syscalls, "openat,close", 12) == 0) {
+			bomsh_openat_mode = 1;
+		}
+	}
+	int new_argc = argc+bomsh_argc+1;
+	char ** new_argv = (char **)malloc( (new_argc+1)* sizeof(char *));
+	if (!new_argv) {
+		fprintf(stderr, "Failed to alloc memory.");
+		exit(0);
+	}
+	// Copy all options to the new_argv array to apply to strace in the end.
+	new_argv[0] = argv0;
+	for (i=0; i<bomsh_argc; i++) {
+		new_argv[i + 1] = (char *)bomsh_argv[i];
+	}
+	for (i=0; i<argc; i++) {
+		new_argv[bomsh_argc+1+i] = argv[i];
+	}
+	new_argv[new_argc] = NULL;
+
+	// must reinitialize getopt() by resetting optind to 0
+	optind = 0;
+	strace_init(new_argc, new_argv);
+	free(new_argv);
+	if (trace_syscalls) free(trace_syscalls);
+	bomsh_hook_init();
+}
+
+// bomsh logging functions
+static FILE *
+bomsh_convert_level_to_logfile(int log_level)
+{
+	FILE *output = NULL;
+	if (log_level == -1) {
+		output = g_bomsh_global.raw_logfile;
+	} else if (log_level == -2) {
+		output = g_bomsh_global.raw_logfile2;
+	} else if (log_level <= bomsh_verbose) {
+		output = g_bomsh_global.logfile;
+	}
+	return output;
+}
+
+// log_level of -1 means raw_logfile, and -2 means raw_logfile2.
+// since there is no log level for raw_logfile/raw_logfile2.
+void
+bomsh_log_printf(int log_level, const char *fmt, ...)
+{
+	FILE *output = bomsh_convert_level_to_logfile(log_level);
+	if (!output) {
+		return;
+	}
+	va_list args;
+	va_start(args, fmt);
+	(void)vfprintf(output, fmt, args);
+	va_end(args);
+}
+
+#ifndef HAVE_FPUTS_UNLOCKED
+# define fputs_unlocked fputs
+#endif
+
+void
+bomsh_log_string(int log_level, const char *str)
+{
+	FILE *output = bomsh_convert_level_to_logfile(log_level);
+	if (!output) {
+		return;
+	}
+	fputs_unlocked(str, output);
+}
+

--- a/.devcontainer/src/bomsh_config.h
+++ b/.devcontainer/src/bomsh_config.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024, Cisco and/or its affiliates.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/omnibor/bomsh/blob/main/LICENSE
+ */
+
+#ifndef BOMSH_CONFIG_H
+#define BOMSH_CONFIG_H
+
+struct bomsh_configs {
+	char *hook_script_file;
+	char *hook_script_cmdopt;
+	char *shell_cmd_file;
+	char *tmpdir;
+	char *logfile;
+	char *raw_logfile;
+	char *syscalls;
+
+	// SHA1/SHA256/both, default is 0, means SHA1 only.
+	// if <0, no hash computation; if >3, same as default of 0
+	// SHA1 = 1, SHA256 = 2, SHA1 + SHA256 = 3, DEFAULT=0
+	int hash_alg;
+
+	// what metadata to record? build_tool, dynlib, etc.
+	//int metadata_to_record;
+	//
+	// generate dependency for C compilation? use separate subprocess or instrument same process with extra "-MD -MF depfile"?
+	// 0 generates depfile with instrumentation, 1 generates with subprocess, and 2 not generating depfile
+	int generate_depfile;
+
+	// conftest/conftest.o/libconftest.a are output files during ./configure
+	// these output files are ignored by default, since they are not very useful.
+	int handle_conftest;
+
+	// by default, we check prog R_OK|X_OK permission before recording a command.
+	// the below flag will turn off/on this permission check
+	int skip_checking_prog_access;
+
+	// By default, we support non-standard install location of tools, for gcc/clang/ld/patch, etc.
+	// The below flag turn on strict (or exact) prog path check/comparison,
+	// which disables support of non-standard install location of tools.
+	int strict_prog_path;
+};
+extern struct bomsh_configs g_bomsh_config;
+
+// use below for verbosity log_level to indicate logging to raw_logfiles.
+#define BOMSH_RAW_LOGFILE -1
+#define BOMSH_RAW_LOGFILE2 -2
+
+struct bomsh_globals {
+	// output file for logging, with verbosity level support.
+	FILE *logfile;
+
+	// output file for OmniBOR raw logging of ADFs (Artifact Dependency Fragments).
+	FILE *raw_logfile;
+
+	// for sha256 logging if both SHA1 + SHA256 for g_bomsh_config.hash_alg = 3
+	FILE *raw_logfile2;
+};
+extern struct bomsh_globals g_bomsh_global;
+
+extern int bomsh_verbose;
+extern int bomsh_detach_on_pid;
+extern int bomsh_is_pre_exec_program(char *prog);
+extern int bomsh_is_watched_program(char *prog);
+extern int bomsh_is_detach_on_pid_program(char *prog);
+extern pid_t *bomsh_umbrella_pid_stack;
+extern int bomsh_umbrella_pid_top;
+extern int bomsh_is_umbrella_program(char *prog);
+extern char *bomsh_basename(char *path);
+
+extern void bomsh_log_printf(int log_level, const char *fmt, ...);
+extern void bomsh_log_string(int log_level, const char *str);
+
+extern void strace_set_outfname(const char *fname);
+extern void strace_init(int argc, char *argv[]);
+extern void bomsh_init(int argc, char *argv[]);
+
+// read file content, and save file_size to read_len if read_len is not NULL.
+// read one-byte more than file size, and last byte is set to 0 for NULL-terminating string.
+extern char * bomsh_read_file(const char *filepath, long *read_len);
+
+#endif /* !BOMSH_CONFIG_H */

--- a/.devcontainer/src/bomsh_hook.c
+++ b/.devcontainer/src/bomsh_hook.c
@@ -1,0 +1,1936 @@
+/*
+ * Copyright (c) 2024, Cisco and/or its affiliates.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/omnibor/bomsh/blob/main/LICENSE
+ */
+
+#include <sys/stat.h>
+#include "defs.h"
+#include "ptrace.h"
+#include "bomsh_hook.h"
+#include "bomsh_config.h"
+
+static int strcmp_comparator(const void *p, const void *q)
+{
+	return strcmp(* (char * const *) p, * (char * const *) q);
+}
+
+/* token lists for command line parsing */
+static const char *
+gcc_skip_token_list[] = {"-MT", "-MF", "-x", "-I", "-B", "-D", "-L", "-isystem", "-iquote", "-idirafter", "-iprefix",
+	"-isysroot", "-iwithprefix", "-iwithprefixbefore", "-imultilib", "-include",
+	"--param", "-main-file-name", "-internal-externc-isystem", "-internal-isystem",
+	"-fdebug-compilation-dir", "-ferror-limit", "-fmessage-length",
+	"-mrelocation-model", "-mthread-model", "-resource-dir", "-target-cpu"};
+
+static const char *
+linker_skip_tokens[] = {"-m", "-z", "-a", "-A", "-b", "-c", "-e", "-f", "-F", "-G", "-u", "-y", "-Y", "-soname", "--wrap",
+	"--architecture", "--format", "--mri-script", "--entry", "--auxiliary", "--filter", "--gpsize", "--oformat",
+	"--defsym", "--split-by-reloc", "-rpath", "-rpath-link", "--dynamic-linker", "-dynamic-linker"};
+
+static const char *
+strip_skip_token_list[] = {"-F", "--target", "-I", "--input-target", "-O", "--output-target",
+	"-K", "--keep-symbol", "-N", "--strip-symbol", "-R", "--remove-section",
+	"--keep-section", "--remove-relocations"};
+
+static const char *eu_strip_skip_token_list[] = {"-F", "-f", "-R", "--remove-section"};
+
+static void bomsh_token_init(void)
+{
+	qsort(gcc_skip_token_list, sizeof(gcc_skip_token_list)/sizeof(*gcc_skip_token_list), sizeof(char *), strcmp_comparator);
+	qsort(linker_skip_tokens, sizeof(linker_skip_tokens)/sizeof(*linker_skip_tokens), sizeof(char *), strcmp_comparator);
+	qsort(strip_skip_token_list, sizeof(strip_skip_token_list)/sizeof(*strip_skip_token_list), sizeof(char *), strcmp_comparator);
+	qsort(eu_strip_skip_token_list, sizeof(eu_strip_skip_token_list)/sizeof(*eu_strip_skip_token_list), sizeof(char *), strcmp_comparator);
+}
+
+static int bomsh_is_gcc_skip_token(char *token)
+{
+	int num_tokens = sizeof(gcc_skip_token_list)/sizeof(*gcc_skip_token_list);
+	return bsearch(&token, gcc_skip_token_list, num_tokens, sizeof(char *), strcmp_comparator) != NULL;
+}
+
+#if 0
+static int bomsh_is_linker_skip_token(char *token)
+{
+	int num_tokens = sizeof(linker_skip_tokens)/sizeof(*linker_skip_tokens);
+	return bsearch(&token, linker_skip_tokens, num_tokens, sizeof(char *), strcmp_comparator) != NULL;
+}
+#endif
+
+/******** EXECVE instrumentation routines ********/
+
+// create a new memory buffer to hold the argv pointer array and all argument strings
+static char *bomsh_create_param_buf(bomsh_cmd_data_t *cmd, int *buf_size)
+{
+	int cmdline_size = 0;
+        int argc = 0; char **p = cmd->argv;
+	while (*p) {
+		cmdline_size += strlen(*p) + 1;
+		argc++; p++;
+	}
+	char buf[PATH_MAX];
+	int len = 0;
+	if (cmd->root[1]) {
+		// inside chroot, we are forced to use /tmp directory
+		len = sprintf(buf, "-MD -MF /tmp/bomsh_hook_target_dependency_pid%d.d", cmd->pid);
+	} else {
+		len = sprintf(buf, "-MD -MF %s/bomsh_hook_target_dependency_pid%d.d", g_bomsh_config.tmpdir, cmd->pid);
+	}
+	buf[3] = buf[7] = '\0';
+	// there are 3 extra parameters for the argv array
+	argc += 3;
+	int array_size = (argc + 1) * sizeof(char *);
+	int size = array_size + cmdline_size + len + 1;
+	char *new_param_buf = (char *)malloc(size);
+	char **new_array = (char **)new_param_buf;
+	// copy all the parameter strings to new param buffer
+	char *q = new_param_buf + array_size;
+        p = cmd->argv;
+	while (*p) {
+		int plen = strlen(*p) + 1;
+		memcpy(q, *p, plen);
+		*new_array = q; new_array ++; // initialize the array pointer to correct value
+		q += plen; p++;
+	}
+	// initialize the 3 extra argv parameters
+	memcpy(q, buf, len + 1);
+	new_array[0] = q;
+	new_array[1] = q + 4;
+	new_array[2] = q + 8;
+	new_array[3] = NULL;
+	if (buf_size) {
+		*buf_size = size;
+	}
+	cmd->depend_file = strdup(buf + 8);
+	return new_param_buf;
+}
+
+// modify the array pointers with new starting address
+static void bomsh_modify_param_buf(char *param_buf, char *new_addr)
+{
+	char **params = (char **)param_buf;
+	ptrdiff_t diff = new_addr - param_buf;
+	while (*params) {
+		*params += diff;  // adjust with the same diff
+		params++;
+	}
+}
+
+static void dump_new_param_buf(char *param_buf, int buf_size)
+{
+	if (!g_bomsh_global.logfile) { return ; }
+	int level = 5;
+	bomsh_log_printf(level, "\nDump new param buf at %p size: %d\n", param_buf, buf_size);
+	char **params = (char **)param_buf;
+	while (*params) {
+		bomsh_log_printf(level, "%p ", *params);
+		params++;
+	}
+	params ++ ;
+	char *p = (char *)params;
+	char *end = param_buf + buf_size;
+	while (p < end) {
+		bomsh_log_string(level, p);
+		bomsh_log_string(level, " ");
+		p += strlen(p) + 1;
+	}
+	bomsh_log_string(level, "\nDone dumping param buf\n");
+}
+
+#include <sys/user.h>
+#include <sys/reg.h>
+
+// modify/instrument argv of existing execve syscall, to obtain gcc dependency
+static void bomsh_execve_instrument_for_dependency(bomsh_cmd_data_t * cmd)
+{
+	struct tcb *tcp = cmd->tcp;
+	int buf_size = 0;
+	char *new_param_buf = bomsh_create_param_buf(cmd, &buf_size);
+	const unsigned int wordsize = current_wordsize;
+	// on x86_64, RSP register has the stack address
+	char *stack_addr = (char *) ptrace(PTRACE_PEEKUSER, tcp->pid, wordsize*RSP, 0);
+	int new_buf_size = buf_size;
+	//int new_buf_size = (buf_size/wordsize + 1) * wordsize; // do we need address alignment?
+	dump_new_param_buf(new_param_buf, buf_size);
+
+	/* Move further of red zone and make sure we have space for the file name */
+	// 8192 is two memory pages, which should be sufficient for red zone
+	stack_addr -= 8192 + new_buf_size;
+	//stack_addr -= PATH_MAX + new_buf_size; // PATH_MAX is 4096, is usually sufficient
+	//stack_addr -= 128 + PATH_MAX;  // 128 is insufficient for red zone
+	bomsh_log_printf(4, "stack_addr: %p new_param_buf: %p buf_size: %d new_size: %d\n", stack_addr, new_param_buf, buf_size, new_buf_size);
+
+	//bomsh_log_string(4, "will now write new_param_buf to tracee stack\n");
+	// before writing to tracee memory, modify array to point to correct stack address in tracee process
+	bomsh_modify_param_buf(new_param_buf, stack_addr);
+	dump_new_param_buf(new_param_buf, buf_size);
+
+	// writing new_param_buf content to tracee process's stack memory
+	unsigned int nwrite = upoken(tcp, (kernel_ulong_t)stack_addr, new_buf_size, new_param_buf);
+	if (nwrite) {
+		bomsh_log_printf(4, "Succeeded to write upoken for stack nwrite: %d\n", nwrite);
+	} else {
+		bomsh_log_string(4, "Failed to write upoken for stack\n");
+	}
+	if (bomsh_verbose > 10) {
+		// read back to make sure correct content is written to tracee memory
+		char *read_buf = malloc(new_buf_size);
+		if (umoven(tcp, (kernel_ulong_t)stack_addr, new_buf_size, read_buf)) {
+			bomsh_log_string(4, "Failed to read-back umoven for stack\n");
+		} else {
+			bomsh_log_string(4, "Succeeded to read-back umoven for stack\n");
+		}
+		// if insufficient to skip the stack red zone, then reading back does not work
+		dump_new_param_buf(read_buf, buf_size);
+		free(read_buf);
+	}
+
+	// on x86_64, for execve syscall, %rdi = pathname, %rsi = argv, %rdx = envp,
+	// so writing the %rsi register will change the argv parameter of execve syscall.
+	// Now write stack_addr value (which holds new_param_buf) to RSI register
+	ptrace(PTRACE_POKEUSER, tcp->pid, wordsize*RSI, stack_addr);
+	if (bomsh_verbose > 10) {
+		// read back to make sure correct value is written to tracee memory
+		char *myword5 = (char *)ptrace(PTRACE_PEEKUSER, tcp->pid, wordsize*RSI, NULL);
+		bomsh_log_printf(4, "\n=====execve stack_addr changed RSI register value: %p expected: %p\n", myword5, stack_addr);
+	}
+	free(new_param_buf);
+}
+
+/******** end of EXECVE instrumentation routines ********/
+
+/******** SHA1/SHA256 computation routines ********/
+
+#include "sha1.h"
+#include "sha256.h"
+
+#define GITOID_LENGTH_SHA1 20
+#define GITOID_LENGTH_SHA256 32
+
+/* This length should be enough for everything up to 64B, which should cover long type. */
+#define MAX_FILE_SIZE_STRING_LENGTH 256
+
+static void
+calculate_sha1_omnibor (char *afile, unsigned char resblock[])
+{
+	long file_size = 0;
+	char *file_contents = bomsh_read_file(afile, &file_size);
+
+	char init_data[MAX_FILE_SIZE_STRING_LENGTH + 5];
+	int len = sprintf(init_data, "blob %ld", file_size);
+
+	/* Calculate the hash */
+	struct sha1_ctx ctx;
+	sha1_init_ctx(&ctx);
+	sha1_process_bytes(init_data, len + 1, &ctx);
+	sha1_process_bytes(file_contents, file_size, &ctx);
+	sha1_finish_ctx(&ctx, resblock);
+
+	free(file_contents);
+}
+
+// get sha256 value of 32 bytes in resblock.
+static void
+calculate_sha256_omnibor (char *afile, unsigned char resblock[])
+{
+	long file_size = 0;
+	char *file_contents = bomsh_read_file(afile, &file_size);
+
+	char init_data[MAX_FILE_SIZE_STRING_LENGTH + 5];
+	int len = sprintf(init_data, "blob %ld", file_size);
+
+	/* Calculate the hash */
+	struct sha256_ctx ctx;
+	sha256_init_ctx(&ctx);
+	sha256_process_bytes(init_data, len + 1, &ctx);
+	sha256_process_bytes(file_contents, file_size, &ctx);
+	sha256_finish_ctx(&ctx, resblock);
+
+	free(file_contents);
+}
+
+// convert binary byte array to hex string array.
+static void
+bomsh_convert_omnibor_hash(char str_hash[], unsigned char *resblock, unsigned int length)
+{
+	static const char *const lut = "0123456789abcdef";
+	for (unsigned i = 0; i < length; i++) {
+		str_hash[2*i] = lut[resblock[i] >> 4];
+		str_hash[2*i+1] = lut[resblock[i] & 15];
+	}
+}
+
+// get the sha1 string of 40 bytes in str_hash.
+static void
+bomsh_get_omnibor_sha1_hash(char *afile, char str_hash[])
+{
+	unsigned char resblock[GITOID_LENGTH_SHA1];
+	calculate_sha1_omnibor (afile, resblock);
+	bomsh_convert_omnibor_hash(str_hash, resblock, GITOID_LENGTH_SHA1);
+}
+
+// get the sha256 string of 64 bytes in str_hash.
+static void
+bomsh_get_omnibor_sha256_hash(char *afile, char str_hash[])
+{
+	unsigned char resblock[GITOID_LENGTH_SHA256];
+	calculate_sha256_omnibor (afile, resblock);
+	bomsh_convert_omnibor_hash(str_hash, resblock, GITOID_LENGTH_SHA256);
+}
+
+/******** end of SHA1/SHA256 computation routines ********/
+
+/******** shell command add/remove/log routines ********/
+
+// 1024 buckets should be sufficient, my experiments show the max is close to 100 only.
+#define BOMSH_CMDS_SIZE 1024
+static bomsh_cmd_data_t **bomsh_cmds = NULL;
+
+// allocate the cmd_data struct and initialize it
+static bomsh_cmd_data_t *bomsh_new_cmd(struct tcb *tcp, char *pwd, char *root, char *path, char **argv_array)
+{
+	bomsh_cmd_data_t *cmd = (bomsh_cmd_data_t *)calloc(1, sizeof(bomsh_cmd_data_t));
+	cmd->next = NULL;
+	cmd->tcp = tcp;
+	cmd->pid = tcp->pid;
+	cmd->pwd = pwd;
+	cmd->root = root;
+	cmd->path = path;
+	cmd->argv = argv_array;
+	return cmd;
+}
+
+// free all the allocated memory for an array of strings, like argv
+static void bomsh_free_string_array(char **array)
+{
+	if (array) {
+		char **p = array;
+		while (*p) {
+			free(*p); p++;
+		}
+		free(array);
+	}
+}
+
+// free the allocated memory for this command
+static void bomsh_free_cmd(bomsh_cmd_data_t *cmd)
+{
+	// no need to free output_file, since output_file is not allocated.
+	if (cmd->pwd) {
+		free(cmd->pwd);
+	}
+	if (cmd->root) {
+		free(cmd->root);
+	}
+	if (cmd->path) {
+		free(cmd->path);
+	}
+	bomsh_free_string_array(cmd->input_files);
+	bomsh_free_string_array(cmd->input_files2);
+	bomsh_free_string_array(cmd->dynlib_files);
+	bomsh_free_string_array(cmd->argv);
+	if (cmd->input_sha1) {
+		free(cmd->input_sha1[0]); // all the hashes are in a single allocated buffer
+		free(cmd->input_sha1);
+	}
+	if (cmd->input_sha256) {
+		free(cmd->input_sha256[0]); // all the hashes are in a single allocated buffer
+		free(cmd->input_sha256);
+	}
+	if (cmd->depend_file) {
+		const char *prefix = "bomsh_hook_target_dependency_pid";
+		//const char *prefix = "/tmp/bomsh_hook_target_dependency_pid";
+		if (strncmp(bomsh_basename(cmd->depend_file), prefix, strlen(prefix)) == 0) {
+			// delete bomsh-generated dependency files
+			unlink(cmd->depend_file);
+		}
+		free(cmd->depend_file);
+	}
+	free(cmd);
+}
+
+// log an array of string pointers, like the argv array
+static void bomsh_log_string_array(int level, char **array, char *sep, char *header, char *footer)
+{
+	if (array) {
+		if (header) {
+			bomsh_log_string(level, header);
+		}
+		char **p = array;
+		while (*p) {
+			bomsh_log_string(level, sep);
+			bomsh_log_string(level, *p);
+			p++;
+		}
+		if (footer) {
+			bomsh_log_string(level, footer);
+		}
+	}
+}
+
+// for debugging purpose
+static void bomsh_log_cmd_data(bomsh_cmd_data_t *cmd, int level)
+{
+	bomsh_log_printf(level, "\nStart of cmd_data, pid: %d pwd: %s root: %s path: %s", cmd->pid, cmd->pwd, cmd->root, cmd->path);
+	if (cmd->depend_file) {
+		bomsh_log_printf(level, "\ndepend_file: %s", cmd->depend_file);
+	}
+	if (cmd->stdin_file) {
+		bomsh_log_printf(level, "\nstdin_file: %s", cmd->stdin_file);
+	}
+	if (cmd->stdout_file) {
+		bomsh_log_printf(level, "\nstdout_file: %s", cmd->stdout_file);
+	}
+	if (cmd->cat_cmdline) {
+		bomsh_log_printf(level, "\ncat_cmline: %s", cmd->cat_cmdline);
+	}
+	bomsh_log_string_array(level, cmd->argv, (char *)" ", (char *)"\nargv cmdline:", NULL);
+	bomsh_log_printf(level, "\nskip record raw info: %d", cmd->skip_record_raw_info);
+	if (cmd->output_file) {
+		bomsh_log_printf(level, "\noutput file: %s", cmd->output_file);
+	}
+	bomsh_log_printf(level, "\n#inputs: %d", cmd->num_inputs);
+	bomsh_log_string_array(level, cmd->input_files, (char *)"\n ", (char *)"\ninput files:", NULL);
+	bomsh_log_string_array(level, cmd->dynlib_files, (char *)"\n ", (char *)"\ndynamic libraries:", NULL);
+	bomsh_log_string_array(level, cmd->input_sha1, (char *)"\n ", (char *)"\ninput file SHA1 hashes:", NULL);
+	bomsh_log_string_array(level, cmd->input_sha256, (char *)"\n ", (char *)"\ninput file SHA256 hashes:", NULL);
+	bomsh_log_string_array(level, cmd->input_files2, (char *)" ", (char *)"\ninput files2:", NULL);
+	bomsh_log_string(level, "\nEnd of cmd_data\n");
+}
+
+//static int bomsh_cmd_num = 0;  // useful to collect some stats about bomsh_cmds size
+
+// Add a new node with pid and relevant info
+static bomsh_cmd_data_t *
+bomsh_add_cmd(struct tcb *tcp, char *pwd, char *root, char *path, char **argv_array)
+{
+	bomsh_cmd_data_t *cmd = bomsh_new_cmd(tcp, pwd, root, path, argv_array);
+	int index = tcp->pid % BOMSH_CMDS_SIZE;
+	if (bomsh_cmds[index]) {  // insert the node at the head of the linked list
+		cmd->next = bomsh_cmds[index]->next;
+	}
+	bomsh_cmds[index] = cmd;
+	//bomsh_log_printf(4, "\nADD bomsh_cmd_num: %d\n", bomsh_cmd_num++);
+	return cmd;
+}
+
+// Remove a node of pid, return it if found
+static bomsh_cmd_data_t *bomsh_remove_cmd(pid_t pid)
+{
+	if (!bomsh_cmds) {
+		return NULL;
+	}
+	int index = pid % BOMSH_CMDS_SIZE;
+	bomsh_cmd_data_t *cmd = bomsh_cmds[index];
+	bomsh_cmd_data_t *prev = NULL;
+	while (cmd) {
+		// find the pid node and remove it from the linked list
+		if (cmd->pid == pid) {
+			if (prev) {
+				prev->next = cmd->next;
+			} else {
+				bomsh_cmds[index] = cmd->next;
+			}
+			//bomsh_log_printf(4, "\nDEL bomsh_cmd_num: %d\n", bomsh_cmd_num--);
+			return cmd;
+		}
+		prev = cmd;
+		cmd = cmd->next;
+	}
+	return NULL;
+}
+
+#if 0
+// Find a node for pid
+bomsh_cmd_data_t *bomsh_get_cmd(pid_t pid)
+{
+	int index = pid % BOMSH_CMDS_SIZE;
+	bomsh_cmd_data_t *cmd = bomsh_cmds[index];
+	while (cmd) {
+		if (cmd->pid == pid) {
+			return cmd;
+		}
+		cmd = cmd->next;
+	}
+	return cmd;
+}
+#endif
+
+/******** end of shell command add/remove/log routines ********/
+
+/******** EXECVE cmd recording routines ********/
+
+// Get number of argv in tracee's argv array
+static unsigned int
+get_argc(struct tcb *const tcp, kernel_ulong_t addr)
+{
+	if (!addr)
+		return 0;
+
+	const unsigned int wordsize = current_wordsize;
+	kernel_ulong_t prev_addr = 0;
+	unsigned int n;
+
+	for (n = 0; addr > prev_addr; prev_addr = addr, addr += wordsize, ++n) {
+		kernel_ulong_t word = 0;
+		if (umoven(tcp, addr, wordsize, &word)) {
+			if (n == 0)
+				return 0;
+
+			addr = 0;
+			break;
+		}
+		if (word == 0)
+			break;
+	}
+	return n;
+}
+
+// copy a single string from tracee process.
+// return a new string allocated in tracer process
+static char *
+copy_single_str(struct tcb *const tcp, kernel_ulong_t addr)
+{
+	static char *str;
+	unsigned int size;
+	int rc;
+
+	if (!addr) {
+		return NULL;
+	}
+	/* Allocate static buffers if they are not allocated yet. */
+	if (!str) {
+		str = xmalloc(max_strlen + 1);
+	}
+
+	/* Fetch one byte more because string_quote may look one byte ahead. */
+	size = max_strlen + 1;
+	rc = umovestr(tcp, addr, size, str);
+
+	if (rc < 0) {
+		return NULL;
+	}
+	return(strdup(str));
+}
+
+// Copy the array of char * pointers of argv in tracee process.
+// the new argv array in tracer's process is allocated and needs to be freed after use.
+static char **
+copy_argv_array(struct tcb *const tcp, kernel_ulong_t addr)
+{
+	if (!addr) {
+		return NULL;
+	}
+
+	const unsigned int wordsize = current_wordsize;
+	kernel_ulong_t prev_addr = 0;
+	unsigned int n = 0;
+
+	unsigned int argc = get_argc(tcp, addr);
+	char **array = (char **)xmalloc( (argc+1) * sizeof(char *));
+
+	for (;; prev_addr = addr, addr += wordsize, ++n) {
+		union {
+			unsigned int w32;
+			kernel_ulong_t wl;
+			char data[sizeof(kernel_ulong_t)];
+		} cp;
+
+		if (addr < prev_addr || umoven(tcp, addr, wordsize, cp.data)) {
+			if (n == 0) {
+				return NULL;
+			}
+			break;
+		}
+
+		const kernel_ulong_t word = (wordsize == sizeof(cp.w32))
+					    ? (kernel_ulong_t) cp.w32 : cp.wl;
+		if (word == 0)
+			break;
+
+		array[n] = copy_single_str(tcp, word);
+	}
+        array[argc] = NULL;
+	return array;
+}
+
+// copy the program path in tracee's process
+static char *
+copy_path(struct tcb *const tcp, const kernel_ulong_t addr)
+{
+	char path[PATH_MAX];
+	int nul_seen;
+	unsigned int n = PATH_MAX - 1;
+
+	if (!addr) {
+		return NULL;
+	}
+
+	/* Fetch one byte more to find out whether path length > n. */
+	nul_seen = umovestr(tcp, addr, n + 1, path);
+	if (nul_seen <= 0)
+		return NULL;
+	else {
+		path[n] = 0;
+	}
+
+	return strdup(path);
+}
+
+// get root directory for a traced process.
+static char * bomsh_get_rootdir(struct tcb *tcp)
+{
+	char cwd_file[32] = "";
+	static char bomsh_rootdir[PATH_MAX] = "";
+	sprintf(cwd_file, "/proc/%d/root", tcp->pid);
+	int bytes = readlink(cwd_file, bomsh_rootdir, PATH_MAX);
+	//if (bytes == -1 || (bytes == 1 && bomsh_rootdir[0] == '/')) {
+	if (bytes == -1) {
+		return NULL;
+	}
+	bomsh_rootdir[bytes] = 0;
+	return strdup(bomsh_rootdir);
+}
+
+// get current working directory for a traced process.
+// the returned pwd contains the /root part if in chroot environment
+static char * bomsh_get_pwd(struct tcb *tcp)
+{
+	char cwd_file[32] = "";
+	static char bomsh_pwddir[PATH_MAX] = "";
+	sprintf(cwd_file, "/proc/%d/cwd", tcp->pid);
+	int bytes = readlink(cwd_file, bomsh_pwddir, PATH_MAX);
+	if (bytes == -1) {
+		return NULL;
+	}
+	bomsh_pwddir[bytes] = 0;
+	return strdup(bomsh_pwddir);
+}
+
+// Get the real path, or absolute path including /root/pwd/afile
+// returns allocated buffer to hold the result, and user needs to free it.
+static char *get_real_path(bomsh_cmd_data_t *cmd, char *afile)
+{
+	char path[PATH_MAX];
+	if (afile[0] != '/') {
+		strcpy(path, cmd->pwd);  // cmd->pwd contains cmd->root already
+		strcat(path, "/");
+		strcat(path, afile);
+		return strdup(path);
+	}
+	// afile is absolute path, starting with '/' character.
+	if (cmd->root[1]) {
+		int len_root = strlen(cmd->root);
+		if (strncmp(afile, cmd->root, len_root)) {
+			// afile does not start with cmd->root, then concatenate root with afile
+			strcpy(path, cmd->root);
+			strcat(path, afile);
+			return strdup(path);
+		}
+	}
+	return strdup(afile);
+}
+
+// Get the real path, or absolute path including /root/pwd/afile
+// The RESULT buffer should be big enough to hold the real path.
+// returns the string pointer to the real path, without allocating buffer
+static char *get_real_path22(char *afile, char *result, char *pwd, char *root)
+{
+	char *path = result;
+	if (afile[0] != '/') {
+		strcpy(path, pwd);  // pwd contains root already
+		strcat(path, "/");
+		strcat(path, afile);
+		return path;
+	}
+	// afile is absolute path, starting with '/' character.
+	if (root[1] && strncmp(afile, root, strlen(root))) {
+		// afile does not start with root, then concatenate root with afile
+		strcpy(path, root);
+		strcat(path, afile);
+		return path;
+	}
+	return afile;
+}
+
+// Get the real path, or absolute path including /root/pwd/afile
+// The RESULT buffer should be big enough to hold the real path.
+// returns the string pointer to the real path, without allocating buffer
+static char *get_real_path2(bomsh_cmd_data_t *cmd, char *afile, char *result)
+{
+	return get_real_path22(afile, result, cmd->pwd, cmd->root);
+}
+
+// Get the real path, or absolute path including /root/pwd/afile
+// The RESULT buffer should be big enough to hold the real path.
+// returns the string pointer to the real path, without allocating buffer
+// if noroot_path is not NULL, it will be set to point to /pwd/afile part, without /root prefix.
+static char *get_real_path3(bomsh_cmd_data_t *cmd, char *afile, char *result, char **noroot_path)
+{
+	char *path = result;
+	if (afile[0] != '/') {
+		if (!path) {
+			return NULL;
+		}
+		strcpy(path, cmd->pwd);  // cmd->pwd contains cmd->root already
+		strcat(path, "/");
+		strcat(path, afile);
+		afile = path;
+	}
+	// afile is absolute path, starting with '/' character.
+	else if (cmd->root[1] && strncmp(afile, cmd->root, strlen(cmd->root))) {
+		if (!path) {
+			return NULL;
+		}
+		// afile does not start with cmd->root, then concatenate root with afile
+		strcpy(path, cmd->root);
+		strcat(path, afile);
+		afile = path;
+	}
+	if (noroot_path) {
+		if (cmd->root[1]) {
+			*noroot_path = afile + strlen(cmd->root);
+		} else {
+			*noroot_path = afile;
+		}
+	}
+	return afile;
+}
+
+// check if the path is a regular file
+static int is_regular_file(char *path) {
+	struct stat path_stat;
+	if (stat(path, &path_stat) == 0) {
+		return S_ISREG(path_stat.st_mode);
+	}
+	return 0;
+}
+
+static int bomsh_is_regular_file(char *path, char *pwd, char *root)
+{
+	char buf[PATH_MAX];
+	char *apath = get_real_path22(path, buf, pwd, root);
+	return is_regular_file(apath);
+}
+
+// Check the access permission of a file or a directory
+// return 1 for success, and 0 for failure
+static int bomsh_check_permission(char *path, char *pwd, char *root, int amode)
+{
+	char buf[PATH_MAX];
+	char *apath = get_real_path22(path, buf, pwd, root);
+	if( access( apath, amode ) != 0 ) {
+		bomsh_log_printf(8, "\nFailed to access path: %s\n", apath);
+		return 0;
+	}
+	bomsh_log_printf(8, "\nSucceed to access path: %s\n", apath);
+	return 1;
+}
+
+static void bomsh_prehook_program(bomsh_cmd_data_t *cmd);
+
+// record the command data for the command to execute next: write it to bomsh_cmd_file for later use by bomsh_run_hook.
+// returns 1 when record the command successfully and need to run pre-exec hookup
+// returns 2 when record the command successfully and no need to run pre-exec hookup
+// otherwise, recording fails, returns 0
+// return value is ignored in Bomtrace3
+int bomsh_record_command(struct tcb *tcp, const unsigned int index)
+{
+	char *path = copy_path(tcp, tcp->u_arg[index + 0]);
+        if (!path) {
+                return 0;
+        }
+	if (bomsh_is_detach_on_pid_program(path)) {
+		// no need to record this command or follow its child processes
+		bomsh_detach_on_pid = tcp->pid;
+		bomsh_log_printf(4, "\n\nInfo: umbrella_top=%d bomsh detach pid %d\n", bomsh_umbrella_pid_top, tcp->pid);
+		free(path);
+		return 0;
+	}
+	if (bomsh_is_umbrella_program(path)) {
+		bomsh_umbrella_pid_top ++;
+		bomsh_umbrella_pid_stack[bomsh_umbrella_pid_top] = tcp->pid;
+		bomsh_log_printf(4, "\n\nInfo: top=%d enter bomsh umbrella pid %d\n", bomsh_umbrella_pid_top, tcp->pid);
+	}
+	if (bomsh_umbrella_pid_stack && bomsh_umbrella_pid_top < 0) {
+		// no need to record this command since there is no umbrella process
+		free(path);
+		return 0;
+	}
+	// Either strict_prog_path or not, it has been taken care in the bomsh_is_watched_program() function.
+	if( !bomsh_is_watched_program(path) ) {
+		// file is not watched
+		free(path);
+		return 0;
+	}
+	char *rootdir = bomsh_get_rootdir(tcp);
+	if (!rootdir) {
+		free(path);
+		return 0;
+	}
+	char *pwd = bomsh_get_pwd(tcp);
+	if (!pwd) {
+                free(rootdir);
+		free(path);
+		return 0;
+	}
+	// When there are multiple levels of symlinks, below permission check fails on some platforms like Mageia for /usr/bin/cc
+	// In such case, user can set skip_checking_prog_access=1 in bomtrace.conf file to make it work.
+	//
+	// Checking file permission can return early for non-existent programs, like /usr/local/bin/gcc, etc.
+	// This avoids unnecessary writing of bomsh_cmd.pidXXXX file, which can also incur extra invocation of hook-up progs in pre-exec mode.
+	if (!g_bomsh_config.skip_checking_prog_access && !bomsh_check_permission(path, pwd, rootdir, R_OK|X_OK)) {
+		// file cannot read or execute
+                free(rootdir);
+		free(pwd);
+		free(path);
+		return 0;
+	}
+	// Add this shell command to global bomsh_cmds struct, for later hook analysis
+	char **argv_array = copy_argv_array(tcp, tcp->u_arg[index + 1]);
+	bomsh_cmd_data_t *cmd = bomsh_add_cmd(tcp, pwd, rootdir, path, argv_array);
+	// run hook program in pre-exec mode
+	bomsh_prehook_program(cmd);
+	return 1;
+}
+
+/******** end of EXECVE cmd recording routines ********/
+
+// start of invoking child process functions
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+
+// run a program in child process, with potential chroot and chdir
+static int bomsh_run_child_prog(char **args, char *root, char *pwd)
+{
+	pid_t pid;
+	pid = fork();  // clone the process
+	if (pid < 0) {
+		bomsh_log_string(4, "Fork Failed\n");
+		return 1;
+	}
+	else if (pid == 0) { /* Child process */
+		/* close the stdout for the child process */
+		// must open before chroot, since /dev/null may not exist after chroot
+		int output_fd = open("/dev/null", O_WRONLY);
+
+		if (root && strcmp(root, "/") && chroot(root) != 0) {
+			bomsh_log_string(4, "chroot() Failed\n");
+			exit(EXIT_FAILURE);
+		}
+		if (pwd && chdir(pwd) != 0) {
+			bomsh_log_string(4, "chdir() Failed\n");
+			exit(EXIT_FAILURE);
+		}
+
+		// below is a relative path to /root/pwd directory, thus open it after chroot/chdir.
+		//int output_fd = open("yon-ofile.txt", O_WRONLY | O_CREAT | O_TRUNC);
+		// Replace the child's stdout and stderr handles with the new file handle:
+		if (dup2(output_fd, STDOUT_FILENO) < 0) {
+			bomsh_log_string(4, "dup2(stdout) Failed\n");
+			exit(EXIT_FAILURE);
+		}
+		if (dup2(output_fd, STDERR_FILENO) < 0) {
+			bomsh_log_string(4, "dup2(stderr) Failed\n");
+			exit(EXIT_FAILURE);
+		}
+
+		execvp(args[0], args);  // replace the current process image with a new one
+
+		/* If execvp returns, it must have failed */
+		bomsh_log_string(4, "Execvp Failed\n");
+		exit(EXIT_FAILURE);
+	}
+	else { /* Parent process */
+		/* The parent will wait for the child to complete */
+		int status;
+		if ( waitpid(pid, &status, 0) == -1 ) {
+			bomsh_log_string(4, "waitpid Failed\n");
+			return EXIT_FAILURE;
+		}
+		bomsh_log_string(4, "\nChild Complete\n");
+	}
+
+	return 0;
+}
+// end of invoking subprocess functions
+
+/******** gcc dependency file processing routines ********/
+
+/*
+ * Check if it is gcc/cc installed at non-standard location.
+ * like /usr/bin/x86_64-mageia-linux-gnu-gcc on Mageia
+ * /sw/packages/gcc/c4.7.0-p5/x86_64-linux/bin/gcc
+ * /auto/binos-tools/llvm11/llvm-11.0-p22/bin/clang-11
+ */
+static int is_special_cc_compiler(char *prog)
+{
+	int len = strlen(prog);
+	return  (prog[len-1] == 'c' && prog[len-2] == 'c' &&
+			(prog[len-3] == '/' || prog[len-3] == '-' ||
+			 (prog[len-3] == 'g' && (prog[len-4] == '/' || prog[len-4] == '-'))))
+		|| (prog[len-1] == '+' && prog[len-2] == '+' && prog[len-3] == 'g' &&
+			(prog[len-4] == '/' || prog[len-4] == '-' ||
+			 (prog[len-7] == 'c' && prog[len-6] == 'l' && prog[len-5] == 'a' && prog[len-4] == 'n')))
+		// || (strncmp(prog + len - 7, "clang++", 7) == 0)
+		|| (strncmp(prog + len - 5, "clang", 5) == 0)
+		|| (strncmp(prog, "clang", 5) == 0);
+		//|| (strncmp(bomsh_basename(prog), "clang", 5) == 0);
+	//return strncmp(prog + len - 3, "gcc") == 0;
+}
+
+static int is_cc_compiler(char *prog)
+{
+	return is_special_cc_compiler(prog);
+	//return strcmp(prog, "/usr/bin/gcc") == 0;
+}
+
+// check if a token is in the watched list.
+static int bomsh_is_token_inlist(char *prog, char **prog_list, int num_progs)
+{
+	return bsearch(&prog, prog_list, num_progs, sizeof(char *), strcmp_comparator) != NULL;
+}
+
+#if 0
+// sorted list of linker names
+static const char *g_cc_linker_names[] = {"gold", "ld", "ld.bfd", "ld.gold", "ld.lld"};
+
+static int is_cc_linker(char *prog)
+{
+	char *name = bomsh_basename(prog);
+	int num_tokens = sizeof(g_cc_linker_names)/sizeof(*g_cc_linker_names);
+	return bsearch(&name, g_cc_linker_names, num_tokens, sizeof(char *), strcmp_comparator) != NULL;
+}
+#endif
+
+static int is_shared_library(char *afile)
+{
+	int len = strlen(afile);
+	return strncmp(afile + len - 3, ".so", 3) == 0;
+}
+
+// Get the output file in argv
+static char * get_outfile_in_argv(char **argv)
+{
+	char **p = argv;
+	while (*p) {
+		char *token = *p; p++; // p points to next token already
+		if (strncmp(token, "-o", 2) == 0) {
+			int len = strlen(token);
+			if (len > 2) {
+				return token + 2;
+			} else {
+				return *p;
+			}
+		}
+	}
+	return NULL;
+}
+
+// Is there a token in argv which is exactly the given TOKEN
+static int is_token_in_argv(char **argv, const char *token)
+{
+	char **p = argv;
+	while (*p) {
+		if (strcmp(*p, token) == 0) {
+			return 1;
+		}
+		p++;
+	}
+	return 0;
+}
+
+// Is there a token in argv which starts with a specific PREFIX
+static int is_token_prefix_in_argv(char **argv, const char *prefix)
+{
+	char **p = argv;
+	int len = strlen(prefix);
+	while (*p) {
+		if (strncmp(*p, prefix, len) == 0) {
+			return 1;
+		}
+		p++;
+	}
+	return 0;
+}
+
+// Whether the gcc command compiles from C/C++ source files to intermediate .o/.s/.E only
+static int gcc_is_compile_only(char **argv)
+{
+	if (is_token_in_argv(argv, "-c") ||
+			//is_token_in_argv(argv, "-cc1") ||
+			is_token_in_argv(argv, "-S") ||
+			is_token_in_argv(argv, "-E")) {
+		return 1;
+	}
+	return 0;
+}
+
+// read depend_file and put the list of depend files in the depends array.
+// depend_buf contains the contents of depend_file, with NULL-terminated file paths.
+// returns the number of depend files
+// user needs to free the allocated depends array and depend_buf.
+static int bomsh_read_depend_file(char *depend_file, char ***depends, char **depend_buf, char **output_file)
+{
+	char *depend_str = bomsh_read_file(depend_file, NULL);
+	bomsh_log_printf(22, "\nReading depend_file: %s the whole depend_str:\n%s\n", depend_file, depend_str);
+	if (!depend_str) {
+		return 0;
+	}
+	char *p = strchr(depend_str, ':');
+	if (!p) {
+		return 0;
+	}
+	if (output_file) {  // save the output_file too
+		*p = 0;
+		*output_file = depend_str;
+	}
+	p++;
+	char *prev = NULL;
+	static char *bomsh_depend_array[2000]; // 2000 should be large enough
+	char **arr = bomsh_depend_array;
+	int num_depends = 0;
+	while (*p) {
+		////if (*p == '\n' && *(p+1) == '\n') { // # get the first part only, due to -MP option.
+		if (*p == '\n' && *(p+1) != ' ') { // # get the first part only, due to -MP option.
+			// for next continued line, it always starts with a space character
+			if(prev) {  // found the end of a new depend file
+				num_depends++;
+				*arr = prev; arr++;
+				*p = 0;
+				bomsh_log_printf(22, "found a new depend: %s\n", prev);
+				prev = NULL;
+#if 0
+				if (num_depends >= 2000) { // we will break anyway, no need to log this warning
+					bomsh_log_string(3, "Warning: reached maximum of 2000 depend files\n");
+					break;
+				}
+#endif
+		        }
+			*p = 0;
+			break;
+		}
+		if (*p == ' ' || *p == '\n') {
+			if(prev) {  // found the end of a new depend file
+				num_depends++;
+				*arr = prev; arr++;
+				*p = 0;
+				bomsh_log_printf(22, "found a new depend: %s\n", prev);
+				prev = NULL;
+				if (num_depends >= 2000) {
+					bomsh_log_string(3, "Warning: reached maximum of 2000 depend files\n");
+					break;
+				}
+		        }
+			if (*(p+1) != ' ' && *(p+1) != '\n' && *(p+1) != '\\') {
+				// found the beginning of a new depend file
+				prev = p + 1;
+			}
+		}
+		p++;
+	}
+	bomsh_log_printf(22, "\nDone parsing depend_str, num_depends: %d\n", num_depends);
+	char **depend_array = (char **)malloc(num_depends * sizeof(char *));
+	memcpy(depend_array, bomsh_depend_array, num_depends * sizeof(char *));
+	*depends = depend_array;
+	*depend_buf = depend_str;
+	return num_depends;
+}
+
+// run a child process to generate dependency for GCC compilation
+static void bomsh_invoke_subprocess_for_dependency(bomsh_cmd_data_t *cmd)
+{
+	char **args = NULL;
+	int num_tokens = 0;
+	char **p = cmd->argv;
+	while (*p) {
+		num_tokens++; p++;
+	}
+	args = malloc( (num_tokens + 4) * sizeof(char *) );
+	memcpy(args, cmd->argv, num_tokens * sizeof(char *));
+	char buf[PATH_MAX];
+	if (cmd->root[1]) {
+		sprintf(buf, "-MD -MF /tmp/bomsh_hook_target_dependency_pid%d.d", cmd->pid);
+	} else {
+		sprintf(buf, "-MD -MF %s/bomsh_hook_target_dependency_pid%d.d", g_bomsh_config.tmpdir, cmd->pid);
+	}
+	buf[3] = buf[7] = '\0';
+	char *depend_file = buf + 8;
+	args[num_tokens] = buf;
+	args[num_tokens+1] = buf+4;
+	args[num_tokens+2] = buf+8;
+	args[num_tokens+3] = NULL;
+	// since cmd->pwd contains cmd->root part, we need to adjust the pwd parameter of the below call.
+	if (cmd->root[1]) {
+		bomsh_run_child_prog(args, cmd->root, cmd->pwd + strlen(cmd->root));
+	} else {
+		bomsh_run_child_prog(args, cmd->root, cmd->pwd);
+	}
+	free(args);
+	cmd->depend_file = strdup(depend_file);
+}
+
+// find the depend_file from gcc argv string array
+static char * extract_depend_file_from_cc_argv(char **argv)
+{
+	char **p = argv;
+	while (*p) {
+		char *token = *p;
+		if (strncmp(token, "-Wp,-MD,", 8) == 0) {
+			return strdup(token + 8);
+		} else if (strncmp(token, "-Wp,-MMD,", 9) == 0) {
+			return strdup(token + 9);
+		}
+		if (strcmp(token, "-MF") == 0) {
+			if (*(p+1)) {
+				return strdup(*(p+1));
+			}
+		}
+		p++;
+	}
+	return NULL;
+}
+
+/******** end of gcc dependency file processing routines ********/
+
+/******** recording ADF (Artifact Dependency Fragment) raw_info routines ********/
+
+/*
+ * afile must be real_path, including cmd->root
+ * the computed hash is saved in ahash character array
+ */
+static void bomsh_get_hash(char *afile, int hash_alg, char *ahash)
+{
+	if (hash_alg == 2) {
+		bomsh_get_omnibor_sha256_hash(afile, ahash);
+	} else {
+		bomsh_get_omnibor_sha1_hash(afile, ahash);
+	}
+}
+
+// get the hash for afile, which is usually relative path
+static void bomsh_cmd_get_hash(bomsh_cmd_data_t *cmd, char *afile, int hash_alg, char *ahash)
+{
+	char path[PATH_MAX];
+	char *bfile = get_real_path2(cmd, afile, path);
+	bomsh_get_hash(bfile, hash_alg, ahash);
+}
+
+// ahash should contain the pre-computed hash already, via the bomsh_cmd_get_hash() method
+static void bomsh_record_afile2(bomsh_cmd_data_t *cmd, char *afile, const char *lead, int hash_alg, char *ahash, int level)
+{
+	char path[PATH_MAX];
+	char *afile2 = afile;
+	// Get the noroot_path for afile
+	if (afile[0] != '/') {
+		strcpy(path, cmd->pwd);
+		strcat(path, "/");
+		strcat(path, afile);
+		afile2 = path;
+		if (cmd->root[1]) {
+			afile2 += strlen(cmd->root);
+		}
+	}
+	bomsh_log_string(level, lead);
+	bomsh_log_string(level, ahash);
+	bomsh_log_string(level, " path: ");
+	bomsh_log_string(level, afile2);
+}
+
+// record a raw_logfile line for a file, with its hash calculated by calling bomsh_get_hash.
+// the recorded path is /pwd/afile, not including /root part, that is, noroot_path
+static void bomsh_record_afile(bomsh_cmd_data_t *cmd, char *afile, const char *lead, int hash_alg, char *ahash, int level)
+{
+	char path[PATH_MAX];
+	char *afile2 = NULL;
+	char *bfile = get_real_path3(cmd, afile, path, &afile2);
+	bomsh_get_hash(bfile, hash_alg, ahash);
+	bomsh_log_string(level, lead);
+	bomsh_log_string(level, ahash);
+	bomsh_log_string(level, " path: ");
+	bomsh_log_string(level, afile2);
+}
+
+// record a list of files, lead is the filetype, like infile or dynlib.
+// array must not be NULL, so verify it before calling this function
+static void bomsh_record_files_array(bomsh_cmd_data_t *cmd, char **array, const char *lead, int hash_alg, char *ahash, int level)
+{
+	char **p = array;
+	while (*p) {
+		bomsh_record_afile(cmd, *p, lead, hash_alg, ahash, level);
+		p++;
+	}
+}
+
+static void bomsh_record_infiles_array(bomsh_cmd_data_t *cmd, char **array, int hash_alg, char *ahash, int level)
+{
+	bomsh_record_files_array(cmd, array, "\ninfile: ", hash_alg, ahash, level);
+}
+
+static void bomsh_record_dynlibs(bomsh_cmd_data_t *cmd, char **array, int hash_alg, char *ahash, int level)
+{
+	bomsh_record_files_array(cmd, array, "\ndynlib: ", hash_alg, ahash, level);
+}
+
+// record both outfile and infiles from the dependency file
+static void bomsh_record_files_from_depfile(bomsh_cmd_data_t *cmd, char *depend_file, int hash_alg, char *ahash, int level)
+{
+	char **depends_array = NULL;
+	char *depends_buf = NULL;
+	char *output_file = NULL;
+	char *depend_file2 = get_real_path(cmd, depend_file);
+	// need to get the real path of the depend file to read successfully
+	bomsh_log_printf(7, "\nRead gcc dependency from depfile: %s real-path: %s\n", depend_file, depend_file2);
+	int num_depends = bomsh_read_depend_file(depend_file2, &depends_array, &depends_buf, &output_file);
+	free(depend_file2);
+	// outfile from depend file may not be correct path, so need to check if it exists
+	if (bomsh_check_permission(output_file, cmd->pwd, cmd->root, F_OK)) {
+		bomsh_record_afile(cmd, output_file, "\noutfile: ", hash_alg, ahash, level);
+	} else {
+		bomsh_log_printf(7, "Warning: not-existent outfile %s from depfile: %s\n", output_file, depend_file);
+		// if the outfile path from depend file does not exist, then try the outfile from argv
+		if (!cmd->output_file) {
+			cmd->output_file = get_outfile_in_argv(cmd->argv);
+		}
+		if (cmd->output_file && bomsh_check_permission(cmd->output_file, cmd->pwd, cmd->root, F_OK)) {
+			bomsh_record_afile(cmd, cmd->output_file, "\noutfile: ", hash_alg, ahash, level);
+		} else {
+			if (cmd->output_file) {
+				bomsh_log_printf(7, "Warning: not-existent output file %s from argv\n", cmd->output_file);
+			} else {
+				bomsh_log_string(7, "Warning: no output file found from argv\n");
+			}
+			// anyway, let's log the outfile from the depend file
+			bomsh_record_afile(cmd, output_file, "\noutfile: ", hash_alg, ahash, level);
+		}
+	}
+	for (int i=0; i<num_depends; i++) {
+		bomsh_record_afile(cmd, depends_array[i], "\ninfile: ", hash_alg, ahash, level);
+	}
+	free(depends_array);
+	free(depends_buf);
+}
+
+static void bomsh_record_out_infiles(bomsh_cmd_data_t *cmd, int hash_alg, char *ahash, int level)
+{
+	// cmd->depend_file should have been verified to exist, when we are here, so no need to check permission again
+	if (cmd->depend_file) {
+		// if we have depend_file, then it must be gcc compilation
+		bomsh_record_files_from_depfile(cmd, cmd->depend_file, hash_alg, ahash, level);
+	} else {
+		bomsh_record_afile(cmd, cmd->output_file, "\noutfile: ", hash_alg, ahash, level);
+		if (cmd->input_files) {
+			bomsh_record_infiles_array(cmd, cmd->input_files, hash_alg, ahash, level);
+		}
+	}
+}
+
+static void bomsh_record_cmdline(bomsh_cmd_data_t *cmd, int level)
+{
+	bomsh_log_string_array(level, cmd->argv, (char *)" ", (char *)"\nbuild_cmd:", NULL);
+}
+
+// record ADF (Artifact Dependency Fragment) for a specific hash algorithm
+static void bomsh_record_raw_info_hashalg(bomsh_cmd_data_t *cmd, int hash_alg, char *ahash, int level)
+{
+	bomsh_record_out_infiles(cmd, hash_alg, ahash, level);
+	if (cmd->dynlib_files) {
+		bomsh_record_dynlibs(cmd, cmd->dynlib_files, hash_alg, ahash, level);
+	}
+	bomsh_record_cmdline(cmd, level);
+	bomsh_log_printf(level, "\n==== End of raw info for PID %d process\n\n", cmd->pid);
+	//bomsh_log_string(level, "\n==== End of raw info for this process\n\n");
+}
+
+// record raw_info (ADF) for a shell command
+static void bomsh_record_raw_info(bomsh_cmd_data_t *cmd)
+{
+	if (!g_bomsh_global.raw_logfile) {
+		return;
+	}
+	//if (cmd->skip_record_raw_info || !cmd->output_file) {
+	//if (!cmd->output_file || strcmp(cmd->output_file, "/dev/null") == 0) {
+	if (!cmd->output_file && !cmd->depend_file) {
+		// if -MF option already exists in "gcc -c" cmd, then output_file is NULL, while depend_file is not.
+		return;
+	}
+	// a buffer used for both SHA1 and SHA256 computation
+	char ahash[GITOID_LENGTH_SHA256 * 2 + 1];
+	ahash[GITOID_LENGTH_SHA1 * 2] = 0;
+	ahash[GITOID_LENGTH_SHA256 * 2] = 0;
+	int level = -1;
+	if (g_bomsh_config.hash_alg == 2) { // log sha256 to raw_logfile only
+		bomsh_record_raw_info_hashalg(cmd, 2, ahash, level);
+	} else { // must log sha1 to raw_logfile
+		bomsh_record_raw_info_hashalg(cmd, 1, ahash, level);
+	}
+	if (g_bomsh_config.hash_alg == 3) { // log sha256 to raw_logfile2 too
+		level = -2;
+		bomsh_record_raw_info_hashalg(cmd, 2, ahash, level);
+	}
+}
+
+// record raw info for a single file OUTFILE, which is both input file and output file.
+static void bomsh_record_raw_info2_infile(bomsh_cmd_data_t *cmd, char *outfile, char *in_hash, char **extra_infiles, int hash_alg, char *ahash, int level)
+{
+	bomsh_cmd_get_hash(cmd, outfile, hash_alg, ahash);
+	if (strcmp(ahash, in_hash) == 0) {
+		// no change in file content
+		return;
+	}
+	bomsh_record_afile2(cmd, outfile, "\noutfile: ", hash_alg, ahash, level);
+	bomsh_record_afile2(cmd, outfile, "\ninfile: ", hash_alg, in_hash, level);
+	if (extra_infiles) {
+		bomsh_record_files_array(cmd, extra_infiles, "\ninfile: ", hash_alg, ahash, level);
+	}
+	bomsh_record_cmdline(cmd, level);
+	bomsh_log_printf(level, "\n==== End of raw info for PID %d process\n\n", cmd->pid);
+}
+
+// record raw info for the list of input files
+static void bomsh_record_raw_info2_infiles(bomsh_cmd_data_t *cmd, int hash_alg, char *ahash, int level)
+{
+	char **p = NULL;
+	if (hash_alg == 2) {
+		p = cmd->input_sha256;
+	} else {
+		p = cmd->input_sha1;
+	}
+	for (int i=0; i<cmd->num_inputs; i++, p++) {
+		char *in_hash = *p;
+		//const char *infiles[3] = {"/usr/bin/ls", "/usr/bin/cat", NULL};
+		//bomsh_record_raw_info2_infile(cmd, cmd->input_files[i], in_hash, (char **)infiles, hash_alg, ahash, level);
+		bomsh_record_raw_info2_infile(cmd, cmd->input_files[i], in_hash, cmd->input_files2, hash_alg, ahash, level);
+	}
+}
+
+// mode 2 of recording raw info: each infile is also outfile, its pre-hash is recorded in input_shaN array.
+static void bomsh_record_raw_info2(bomsh_cmd_data_t *cmd)
+{
+	if (!g_bomsh_global.raw_logfile) {
+		return;
+	}
+	//if (cmd->skip_record_raw_info || !cmd->input_files) {
+	if (!cmd->input_files) {
+		return;
+	}
+	char ahash[GITOID_LENGTH_SHA256 * 2 + 1];
+	ahash[GITOID_LENGTH_SHA1 * 2] = 0;
+	ahash[GITOID_LENGTH_SHA256 * 2] = 0;
+	int level = -1;
+	if (g_bomsh_config.hash_alg == 2) { // log sha256 to raw_logfile only
+		bomsh_record_raw_info2_infiles(cmd, 2, ahash, level);
+	} else { // must log sha1 to raw_logfile
+		bomsh_record_raw_info2_infiles(cmd, 1, ahash, level);
+	}
+	if (g_bomsh_config.hash_alg == 3) { // log sha256 to raw_logfile2 too
+		level = -2;
+		bomsh_record_raw_info2_infiles(cmd, 2, ahash, level);
+	}
+}
+
+/******** end of recording ADF (Artifact Dependency Fragment) raw_info routines ********/
+
+// check if a library exists in a list of library paths
+// if it exists, return allocated buffer to hold the path
+static char * find_lib_in_libpaths(bomsh_cmd_data_t *cmd, char *libfile, char **library_paths, int num_lib_paths, char *suffix)
+{
+	char buf[PATH_MAX];
+	for (int i=0; i<num_lib_paths; i++) {
+		char *lib_path = library_paths[i];
+		strcpy(buf, lib_path);
+		strcat(buf, "/lib");
+		strcat(buf, libfile);
+		strcat(buf, suffix);
+		if (bomsh_check_permission(buf, cmd->pwd, cmd->root, F_OK)) {
+			return strdup(buf);
+		}
+	}
+	return NULL;
+}
+
+// log a list of files for gcc
+static void log_gcc_subfiles(int level, char **libs, int num_libs, const char *lead)
+{
+	bomsh_log_string(level, lead);
+	for (int i=0; i<num_libs; i++) {
+		bomsh_log_string(level, " ");
+		bomsh_log_string(level, libs[i]);
+	}
+}
+
+// Parse cmd->argv, and get all files from the command line
+static void bomsh_get_gcc_subfiles(bomsh_cmd_data_t *cmd)
+{
+	char *output_file = NULL;
+
+	char *system_library_paths[] = {(char *)"/usr/lib64", NULL};
+	int num_libpaths = 0;
+	int libpaths_size = 100;
+	char **library_paths = NULL;
+	int num_libnames = 0;
+	int libnames_size = 100;
+	char **library_names = NULL;
+	int subfiles_size = 100;
+	int num_subfiles = 0;
+	char **subfiles = malloc(subfiles_size * sizeof(char *));
+
+	char **p = cmd->argv;
+	p++; // start with argv[1]
+	while (*p) {
+		char *token = *p; p++; // p points to next token already
+#if 1
+		// the -o option should have been handled earlier by get_outfile_in_argv, so save the check here
+		// well, we still need to handle this -o option, otherwise, the outfile will be added to infiles
+		if (strncmp(token, "-o", 2) == 0) {
+			int len = strlen(token);
+			if (len > 2) {
+				output_file = token + 2;
+			} else {
+				// p already points to next token, which is output file
+				output_file = *p;
+				p++; // move to next token
+			}
+#if 0
+			if (output_file && strcmp(output_file, "/dev/null") == 0) {
+				// well, this case should have been handled earlier, so we should not reach here
+				bomsh_log_string(3, "NULL outfile, no need to process gcc command\n");
+				cmd->skip_record_raw_info = 1;
+				free(subfiles);
+				if (library_paths) free(library_paths);
+				if (library_names) free(library_names);
+				return;
+			}
+#endif
+			bomsh_log_printf(4, "found output file %s\n", output_file);
+			continue;
+		}
+#endif
+		if (strncmp(token, "-L", 2) == 0) {
+			if (!library_paths) {
+				library_paths = malloc(libpaths_size * sizeof(char *));
+			}
+			if (num_libpaths >= libpaths_size) {
+				libpaths_size *= 2;
+				library_paths = realloc(library_paths, libpaths_size * sizeof(char *));
+			}
+			int len = strlen(token);
+			if (len > 2) {
+				bomsh_log_printf(4, "found library path %s\n", token + 2);
+				library_paths[num_libpaths++] = token + 2;
+			} else {
+				bomsh_log_printf(4, "found library path %s\n", *p);
+				// p already points to next token, which is output file
+				library_paths[num_libpaths++] = *p;
+				p++; // move to next token
+			}
+			continue;
+		}
+		if (strncmp(token, "-l", 2) == 0) {
+			if (!library_names) {
+				library_names = malloc(libnames_size * sizeof(char *));
+			}
+			if (num_libnames >= libnames_size) {
+				libnames_size *= 2;
+				library_names = realloc(library_names, libnames_size * sizeof(char *));
+			}
+			int len = strlen(token);
+			if (len > 2) {
+				bomsh_log_printf(4, "found library name %s\n", token + 2);
+				library_names[num_libnames++] = token + 2;
+			} else {
+				bomsh_log_printf(4, "found library name %s\n", *p);
+				// p already points to next token, which is output file
+				library_names[num_libnames++] = *p;
+				p++; // move to next token
+			}
+			continue;
+		}
+		// C linker ld has a few more options that come with next token
+		//if (bomsh_is_gcc_skip_token(token) || ((is_cc_linker(cmd->path) && bomsh_is_linker_skip_token(token)))) {
+		if (bomsh_is_gcc_skip_token(token)) {
+			p++; // move to next token
+			continue;
+		}
+		if (token[0] == '-') {
+			continue;
+		}
+		bomsh_log_printf(4, "found one gcc subfile: %s\n", token);
+		// auto-grow the buffer to hold more subfiles
+		if (num_subfiles >= subfiles_size) {
+			subfiles_size *= 2;
+			subfiles = realloc(subfiles, subfiles_size * sizeof(char *));
+		}
+		subfiles[num_subfiles++] = token;
+	}
+
+	// Handle dynamic and static libraries
+	int num_dyn_libs = 0;
+	// it is sufficient, since #dyn_libs < #subfiles + #libnames
+	char **dyn_libs = malloc((num_subfiles + num_libnames + 1) * sizeof(char *));
+	int num_infiles = 0;
+	// it is sufficient, since #infiles <= #subfiles + #libnames
+	char **infiles = malloc((num_subfiles + num_libnames + 1) * sizeof(char *));
+	int i;
+	log_gcc_subfiles(4, subfiles, num_subfiles, "\nList of subfiles:");
+	// save dynamic libraries and add other subfiles to infiles
+	bomsh_log_string(4, "\nChecking gcc subfiles\n");
+	for (i=0; i<num_subfiles; i++) {
+		if (!bomsh_is_regular_file(subfiles[i], cmd->pwd, cmd->root)) {
+			bomsh_log_printf(4, "not regular file or not-existent subfile: %s\n", subfiles[i]);
+			continue;
+		}
+		if (is_shared_library(subfiles[i])) {
+			dyn_libs[num_dyn_libs++] = strdup(subfiles[i]);
+		} else {
+			infiles[num_infiles++] = strdup(subfiles[i]);
+		}
+	}
+
+	// save dynamic libraries and add static libraries to infiles
+	log_gcc_subfiles(4, library_paths, num_libpaths, "\nList of library paths:");
+	log_gcc_subfiles(4, library_names, num_libnames, "\nList of library names:");
+	for (i=0; i<num_libnames; i++) {
+		char *libfile = NULL;
+		if ((libfile = find_lib_in_libpaths(cmd, library_names[i], library_paths, num_libpaths, (char *)".so"))) {
+			bomsh_log_printf(4, "\nAdding dynamic library %s\n", libfile);
+			dyn_libs[num_dyn_libs++] = libfile;
+		} else if ((libfile = find_lib_in_libpaths(cmd, library_names[i], library_paths, num_libpaths, (char *)".a"))) {
+			// this is static library
+			bomsh_log_printf(4, "\nAdding static library %s\n", libfile);
+			infiles[num_infiles++] = libfile;
+		} else if ((libfile = find_lib_in_libpaths(cmd, library_names[i], system_library_paths, 1, (char *)".so"))) {
+			// try the system library search at the end
+			bomsh_log_printf(4, "\nAdding system dynamic library %s\n", libfile);
+			dyn_libs[num_dyn_libs++] = libfile;
+		} else if ((libfile = find_lib_in_libpaths(cmd, library_names[i], system_library_paths, 1, (char *)".a"))) {
+			// try the system library search at the end
+			bomsh_log_printf(4, "\nAdding system static library %s\n", libfile);
+			dyn_libs[num_dyn_libs++] = libfile;
+		}
+	}
+	log_gcc_subfiles(4, infiles, num_infiles, "\nList of infiles:");
+	log_gcc_subfiles(4, dyn_libs, num_dyn_libs, "\nList of dyn_libs:");
+
+	// Save the results in cmd_data struct
+	infiles[num_infiles] = NULL;
+	cmd->num_inputs = num_infiles;
+	cmd->input_files = infiles;
+	if (num_dyn_libs) {
+		dyn_libs[num_dyn_libs] = NULL;
+		cmd->dynlib_files = dyn_libs;
+	} else {
+		free(dyn_libs);
+	}
+	if (output_file) cmd->output_file = output_file;
+	free(subfiles);
+	if (library_paths) free(library_paths);
+	if (library_names) free(library_names);
+}
+
+static void bomsh_process_gcc_command(bomsh_cmd_data_t *cmd, int pre_exec_mode)
+{
+	if (pre_exec_mode) {
+		if (is_token_in_argv(cmd->argv, "-MF") ||
+				is_token_prefix_in_argv(cmd->argv, "-Wp,-MD,") ||
+				is_token_prefix_in_argv(cmd->argv, "-Wp,-MMD,")) {
+			cmd->depend_file = extract_depend_file_from_cc_argv(cmd->argv);
+			bomsh_log_string(3, "pre-exec mode, found cc command with depend-file\n");
+			return;
+		}
+
+		// handle the -o option first, so that we can skip some undesired outfile earlier
+		cmd->output_file = get_outfile_in_argv(cmd->argv);
+		if (cmd->output_file) {
+			bomsh_log_printf(4, "cmdline found output file %s\n", cmd->output_file);
+			if (strcmp(cmd->output_file, "/dev/null") == 0) {
+				// no need to do anything if output is /dev/null
+				bomsh_log_string(3, "\nThe output file is /dev/null, skip recording raw info\n");
+				cmd->skip_record_raw_info = 1;
+				return;
+			}
+		}
+
+		if (!g_bomsh_config.handle_conftest) {
+			// outfiles are usually conftest/conftest.o/conftest2.o
+	       		if (cmd->output_file && strncmp(bomsh_basename(cmd->output_file), "conftest", strlen("conftest")) == 0) {
+				bomsh_log_string(3, "\nconftest outfile, will skip recording raw info\n");
+				cmd->skip_record_raw_info = 1;
+				return;
+			}
+			if (!cmd->input_files) bomsh_get_gcc_subfiles(cmd);
+			if (!cmd->num_inputs || (cmd->num_inputs == 1 && strncmp(bomsh_basename(cmd->input_files[0]), "conftest", strlen("conftest")) == 0)) {
+				// infiles are usually conftest.c/conftest.cpp
+				bomsh_log_string(3, "\nconftest infile, will skip recording raw info\n");
+				cmd->skip_record_raw_info = 1;
+				return;
+			}
+		}
+
+		if (gcc_is_compile_only(cmd->argv)) {
+			if (!cmd->input_files) bomsh_get_gcc_subfiles(cmd);
+			//if (!cmd->input_files || (cmd->num_inputs == 1 && strcmp(cmd->input_files[0], "/dev/null") == 0)) {
+			if (!cmd->num_inputs || (cmd->num_inputs == 1 && strcmp(cmd->input_files[0], "/dev/null") == 0)) {
+				bomsh_log_string(3, "\nThere is no input file, or input is /dev/null, skip recording raw info\n");
+				cmd->skip_record_raw_info = 1;
+				return;
+			}
+			if (g_bomsh_config.generate_depfile == 0) {
+				// Add "-MD -MF depfile" option to existing argv to generate dependency file by default
+				bomsh_log_string(3, "\npre-exec mode, instrument gcc command for dependency\n");
+				bomsh_execve_instrument_for_dependency(cmd);
+			} else if (g_bomsh_config.generate_depfile == 1) {
+				// Invoke a child process to generate dependency file
+				bomsh_log_string(3, "\npre-exec mode, run child-process gcc for dependency\n");
+				bomsh_invoke_subprocess_for_dependency(cmd);
+			}
+		}
+		return;
+	}
+
+	// non-pre-exec mode, invoked after the execve syscall
+	if (cmd->skip_record_raw_info) return;
+#if 0
+	if (cmd->depend_file) {  // some debugging code for dependency file parsing
+		char buf[500]; static int mydep_count = 0;
+		char *path = get_real_path(cmd, cmd->depend_file);
+		sprintf(buf, "mkdir -p /tmp/mydepend; cp %s /tmp/mydepend/%s.%d", path, bomsh_basename(cmd->depend_file), mydep_count++);
+		bomsh_log_printf(3, "try to copy depend file: %s, copy cmd: %s\n", cmd->depend_file, buf);
+		if (system(buf) == -1) {
+			bomsh_log_string(3, "Failed to invoke system cp gcc_dep.d command\n");
+		}
+		free(path);
+	}
+#endif
+	if (!cmd->depend_file || !bomsh_check_permission(cmd->depend_file, cmd->pwd, cmd->root, R_OK)) {
+		bomsh_log_string(3, "\nAfter EXECVE syscall, no depfile or depfile does not exist, so let's get subfiles in gcc cmd\n");
+		if (cmd->depend_file) {
+			free(cmd->depend_file);
+			cmd->depend_file = NULL;
+		}
+		if (!cmd->input_files) {
+			// if cmd->input_files is not NULL, then we must have run the below function
+			bomsh_get_gcc_subfiles(cmd);
+		}
+		bomsh_log_cmd_data(cmd, 4);
+	}
+	// when we are here, if cmd->depend_file is not NULL, then depend_file must exist;
+	// or if cmd->denpend_file is NULL, then cmd->input_files must not be NULL.
+	bomsh_record_raw_info(cmd);
+}
+
+// get all hashes of input files and put them into cmd->input_shaN array
+// this is for the mode 2 of recording ADF raw info.
+static void get_hash_of_infiles(bomsh_cmd_data_t *cmd)
+{
+	if (g_bomsh_config.hash_alg < 0) {
+		return;
+	}
+	if (!cmd->input_files) {
+		return;
+	}
+	if (!cmd->num_inputs) { // calculate #inputs if not yet calculated
+		char **p = cmd->input_files;
+		while (*p) {
+			p++;
+		}
+		cmd->num_inputs = (p - cmd->input_files)/sizeof(char *);
+	}
+	char *sha1_array = NULL;
+	char *sha256_array = NULL;
+	char **sha1 = NULL;
+	char **sha256 = NULL;
+	int num_inputs = cmd->num_inputs;
+	int hash_alg = g_bomsh_config.hash_alg;
+	if (hash_alg & 2) {
+		cmd->input_sha256 = malloc((num_inputs + 1) * sizeof(char *));
+		// allocate a single buffer to hold all hashes
+		sha256_array = malloc(num_inputs * (GITOID_LENGTH_SHA256 * 2 + 1));
+		sha256 = cmd->input_sha256;
+		sha256[num_inputs] = NULL;
+	}
+	if (hash_alg != 2) {
+		cmd->input_sha1 = malloc((num_inputs + 1) * sizeof(char *));
+		sha1_array = malloc(num_inputs * (GITOID_LENGTH_SHA1 * 2 + 1));
+		sha1 = cmd->input_sha1;
+		sha1[num_inputs] = NULL;
+	}
+	for (int i=0; i<num_inputs; i++) {
+		char buf[PATH_MAX];
+		char *afile = cmd->input_files[i];
+		char *path = get_real_path2(cmd, afile, buf);
+		if (hash_alg & 2) {
+			sha256[i] = sha256_array + i * (GITOID_LENGTH_SHA256 * 2 + 1);
+			sha256[i][GITOID_LENGTH_SHA256 * 2] = 0;
+			bomsh_get_omnibor_sha256_hash(path, sha256[i]);
+		}
+		if (hash_alg != 2) {
+			sha1[i] = sha1_array + i * (GITOID_LENGTH_SHA1 * 2 + 1);
+			sha1[i][GITOID_LENGTH_SHA1 * 2] = 0;
+			bomsh_get_omnibor_sha1_hash(path, sha1[i]);
+		}
+	}
+}
+
+static int is_ar_command(char *name)
+{
+	return strcmp(name, "ar") == 0 || strcmp(name + strlen(name) - 3, "-ar") == 0;
+}
+
+// read list of ar input files from a text file, each line is an input file
+static void ar_read_infiles_from_file(bomsh_cmd_data_t *cmd, char *afile)
+{
+	int array_size = 100;
+	char **array = malloc( array_size * sizeof(char *) );
+	int num_array = 0;
+	char buf[PATH_MAX];
+	char *bfile = get_real_path2(cmd, afile, buf);
+	char *content_file = bomsh_read_file(bfile, NULL);
+	char *p = content_file;
+	char *prev = p;
+	while (*p) {
+		if (*p == '\n') {
+			bomsh_log_printf(4, "found one AR infile: %s\n", prev);
+			*p = 0;
+			array[num_array++] = strdup(prev);
+			if (num_array >= array_size) {
+				array_size *= 2;
+				array = realloc(array, array_size * sizeof(char *));
+			}
+			prev = p+1;
+		}
+		p++;
+	}
+	array[num_array] = NULL;
+	cmd->num_inputs = num_array;
+	cmd->input_files = array;
+	free(content_file);
+	return;
+}
+
+// Parse cmd->argv, and get all files from the command line
+static void get_all_subfiles_in_ar_cmdline(bomsh_cmd_data_t *cmd)
+{
+	char *token1 = NULL;
+	char *token2 = NULL;
+	char **ptoken3 = NULL;
+	char **p = cmd->argv;
+	int num_tokens = 1; p++; // start from argv[1]
+	while (*p) {
+		if (strcmp(*p, "--plugin") == 0) {
+			p += 2;  // skip "--plugin name" part
+			continue;
+		}
+		if (num_tokens == 1) token1 = *p;
+		else if (num_tokens == 2) token2 = *p;
+		else if (num_tokens == 3) ptoken3 = p;
+		p++; num_tokens++;
+	}
+	if (num_tokens < 3) return;
+	if (! ((num_tokens > 3 && (strchr(token1, 'c') || strchr(token1, 'r')))
+		|| (num_tokens == 3 && strchr(token1, 's'))) ) {
+		// # Only "ar -c archive file1...fileN", "ar -c archive @filelist", and "ar -s archive" are supported
+		// # also support "ar rvs archive file1...fileN" format
+		return;
+	}
+	if (!g_bomsh_config.handle_conftest && strcmp(token2, "libconftest.a") == 0) {
+		cmd->skip_record_raw_info = 1;
+		return;
+	}
+	cmd->output_file = token2;
+	if (num_tokens == 3) {  // should be "ar -s archive"
+		char **array = malloc( 2 * sizeof(char *) );
+		array[0] = strdup(token2);
+		array[1] = NULL;
+		cmd->num_inputs = 1;
+		cmd->input_files = array;
+		get_hash_of_infiles(cmd);
+		return;
+	}
+	if (num_tokens > 3) {
+		if ((*ptoken3)[0] == '@') { // "ar -c archive @filelist"
+			ar_read_infiles_from_file(cmd, *ptoken3 + 1);
+			return;
+		}
+		p = ptoken3; // first input file
+	}
+	char **array = malloc( (num_tokens - 2) * sizeof(char *) );
+	int i;
+	for (i=0; i<num_tokens - 3; i++, p++) {
+		array[i] = get_real_path(cmd, *p);
+	}
+	array[i] = NULL;
+	cmd->num_inputs = i;
+	cmd->input_files = array;
+}
+
+/*
+ * Only "ar -c archive file1 file2", "ar -c archive @filelist", and "ar -s archive" are supported
+ */
+static void bomsh_process_ar_command(bomsh_cmd_data_t *cmd, int pre_exec_mode)
+{
+	if (pre_exec_mode) {
+		bomsh_log_string(3, "\npre-exec mode, get subfiles for ar command\n");
+		get_all_subfiles_in_ar_cmdline(cmd);
+		return;
+	} else {
+		if (cmd->skip_record_raw_info) return;
+		bomsh_log_string(3, "\nrecord raw_info for ar command after EXECVE syscall\n");
+		if (cmd->input_sha1 || cmd->input_sha256) { // should be "ar -s archive" cmd
+			bomsh_record_raw_info2(cmd);
+		} else {
+			bomsh_record_raw_info(cmd);
+		}
+	}
+}
+
+static int is_eu_strip_command(char *name)
+{
+	return strcmp(name + strlen(name) - 8, "eu-strip") == 0;
+}
+
+static int is_strip_command(char *name)
+{
+	return strcmp(name, "strip") == 0 || strcmp(name + strlen(name) - 6, "-strip") == 0;
+}
+
+// Parse cmd->argv, and get all files from the command line
+static void get_all_subfiles_in_strip_cmdline(bomsh_cmd_data_t *cmd, char **skip_token_list, int num_tokens)
+{
+	int array_size = 100;
+	int num_array = 0;
+	char **array = malloc(array_size * sizeof(char *));
+	char **p = cmd->argv;
+	p++; // start from argv[1]
+	while (*p) {
+		char *token = *p; p++; // p points to next token already
+		if (bomsh_is_token_inlist(token, skip_token_list, num_tokens)) {
+			p++;  // move to next token
+			bomsh_log_printf(4, "found strip skip token: %s\n", token);
+			continue;
+		}
+		// need to handle -o option
+		if (strncmp(token, "-o", 2) == 0) {
+			int len = strlen(token);
+			if (len > 2) {
+				cmd->output_file = token + 2;
+			} else {
+				cmd->output_file = *p; p++;
+			}
+		}
+		if (token[0] == '-') {
+			continue;
+		}
+		bomsh_log_printf(4, "found strip infile: %s\n", token);
+		array[num_array++] = strdup(token);
+		if (num_array >= array_size) {
+			array_size *= 2;
+			array = realloc(array, array_size * sizeof(char *));
+		}
+	}
+	array[num_array] = NULL;
+	cmd->input_files = array;
+	cmd->num_inputs = num_array;
+	if (!cmd->output_file && num_array) {
+		cmd->output_file = array[0]; // need to set it because record_raw_info checks output_file
+	}
+}
+
+static void bomsh_process_strip_command(bomsh_cmd_data_t *cmd, int pre_exec_mode, int eu_strip)
+{
+	if (!pre_exec_mode) {
+		if (!cmd->output_file) return;
+		bomsh_log_string(3, "\nrecord raw_info for strip command after EXECVE syscall\n");
+		if (strcmp(cmd->output_file, cmd->input_files[0])) {
+			// "-o FILE" option exists, and outfile is different from infile
+			bomsh_record_raw_info(cmd);
+		} else {
+			bomsh_record_raw_info2(cmd);
+		}
+		return;
+	}
+	bomsh_log_string(3, "\npre-exec mode, get subfiles for strip command\n");
+	char **skip_token_list = NULL;
+	int num_skip_tokens = 0;
+	if (eu_strip) {
+		skip_token_list = (char **)eu_strip_skip_token_list;
+		num_skip_tokens = sizeof(eu_strip_skip_token_list)/sizeof(*eu_strip_skip_token_list);
+	} else {
+		skip_token_list = (char **)strip_skip_token_list;
+		num_skip_tokens = sizeof(strip_skip_token_list)/sizeof(*strip_skip_token_list);
+	}
+	get_all_subfiles_in_strip_cmdline(cmd, skip_token_list, num_skip_tokens);
+	if (!cmd->output_file) {
+		bomsh_log_string(8, "Empty output/input file, do nothing\n");
+		return;
+	}
+	if (strcmp(cmd->output_file, cmd->input_files[0]) == 0) {
+		get_hash_of_infiles(cmd);
+	}
+}
+
+/******** top level command handling routines ********/
+
+// main routine to handle all recorded shell commands.
+// if pre_exec_mode is 1, it means before the EXECVE syscall
+// if pre_exec_mode is 0, it means after  the EXECVE syscall
+static void bomsh_process_shell_command(bomsh_cmd_data_t *cmd, int pre_exec_mode)
+{
+	char *prog = cmd->path;
+	char *name = bomsh_basename(prog);
+	if (is_cc_compiler(name)) {
+		bomsh_process_gcc_command(cmd, pre_exec_mode);
+	} else if (is_ar_command(name)) {
+		bomsh_process_ar_command(cmd, pre_exec_mode);
+	} else if (is_eu_strip_command(name)) {
+		bomsh_process_strip_command(cmd, pre_exec_mode, 1);
+	} else if (is_strip_command(name)) {
+		bomsh_process_strip_command(cmd, pre_exec_mode, 0);
+	} else {
+		bomsh_log_printf(15, "\nNot-supported shell command: %s\n", prog);
+	}
+}
+
+// hook the program in pre-exec mode, that is, before the execve syscall
+static void bomsh_prehook_program(bomsh_cmd_data_t *cmd)
+{
+	bomsh_log_printf(4, "\n---start prehook pid %d befor EXECVE syscall", cmd->pid);
+	bomsh_log_cmd_data(cmd, 6);
+	bomsh_process_shell_command(cmd, 1);
+	bomsh_log_cmd_data(cmd, 5);
+	bomsh_log_printf(4, "\n----done prehook pid %d befor execve syscall\n", cmd->pid);
+}
+
+// invoked after the execve syscall and after it
+void bomsh_hook_program(int pid)
+{
+	bomsh_log_printf(3, "\n====hook_program pid %d after EXECVE syscall", pid);
+	bomsh_cmd_data_t *cmd = bomsh_remove_cmd(pid);
+	if (!cmd) {
+		bomsh_log_printf(3, "\n===No pid %d cmd_data found\n", pid);
+		return;
+	}
+	bomsh_log_cmd_data(cmd, 4);
+	bomsh_process_shell_command(cmd, 0);
+	bomsh_free_cmd(cmd);
+	bomsh_log_printf(3, "\n====hook_program deleting pid %d cmd, DONE==\n", pid);
+}
+
+void bomsh_hook_init(void)
+{
+	bomsh_token_init();
+	if (!bomsh_cmds) {
+		bomsh_cmds = (bomsh_cmd_data_t **)malloc(BOMSH_CMDS_SIZE * sizeof(char *));
+		memset(bomsh_cmds, 0, BOMSH_CMDS_SIZE * sizeof(char *));
+	}
+}
+

--- a/.devcontainer/src/bomsh_hook.h
+++ b/.devcontainer/src/bomsh_hook.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024, Cisco and/or its affiliates.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/omnibor/bomsh/blob/main/LICENSE
+ */
+
+#ifndef BOMSH_HOOK_H
+#define BOMSH_HOOK_H
+
+typedef struct bomsh_cmddata {
+	struct bomsh_cmddata *next;
+	struct tcb *tcp;
+	pid_t pid;
+	int skip_record_raw_info; // if non-zero, then skip recording raw info for this cmd
+
+	int num_inputs; // number of input files
+	char *pwd;  // current working directory
+	char *root;  // root dir for chroot environment
+	char *path;  // path of program binary
+	char **argv;  // argv array, last array element is NULL pointer
+	char *output_file; // the output file of this command
+	char **input_files; // the input files of this command, array of pointers, last is NULL
+	char **input_files2; // the unchanged input files of this command, array of pointers, last is NULL
+	char **input_sha1; // the SHA1 hashes of input files, array of pointers, last is NULL
+	char **input_sha256; // the SHA256 hashes of input files, array of pointers, last is NULL
+	char *depend_file; // the created depend file for gcc compile
+	char **dynlib_files; // the dynamic library files of gcc command, array of pointers, last is NULL
+
+	char *stdin_file; // the stdin for the patch command, which can be a pipe
+	char *stdout_file; // the stdout for the cat command, which can be a pipe
+	char *cat_cmdline; // the associated cat command line for patch command
+} bomsh_cmd_data_t;
+
+// for the patch command, the input_files contains the list of files to apply the patch,
+// and input_sha1 and input_sha256 are the hashes before applying the patch.
+// and input_files2 contains the patch file itself, which does not change before and after applying the patch.
+// any additional input files that do not change will be put into this input_files2 list.
+
+// record command and run some prehook before EXECVE syscall
+extern int bomsh_record_command(struct tcb *tcp, const unsigned int index);
+
+// run the analysis and record raw info after EXECVE syscall
+extern void bomsh_hook_program(int pid);
+
+// initialize function
+extern void bomsh_hook_init(void);
+
+#endif /* !BOMSH_HOOK_H */

--- a/.devcontainer/src/sha1.c
+++ b/.devcontainer/src/sha1.c
@@ -1,0 +1,360 @@
+/* sha1.c - Functions to compute SHA1 message digest of files or
+   memory blocks according to the NIST specification FIPS-180-1.
+
+   Copyright (C) 2000-2001, 2003-2006, 2008-2023 Free Software Foundation, Inc.
+
+   This file is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   This file is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+/* Written by Scott G. Miller
+   Credits:
+      Robert Klep <robert@ilse.nl>  -- Expansion function fix
+*/
+
+#include <config.h>
+#include "sha1.h"
+
+/* Specification.  */
+#if HAVE_OPENSSL_SHA1
+# define GL_OPENSSL_INLINE _GL_EXTERN_INLINE
+#endif
+
+#include <stdint.h>
+#include <string.h>
+
+#include <byteswap.h>
+#ifdef WORDS_BIGENDIAN
+# define SWAP(n) (n)
+#else
+# define SWAP(n) bswap_32 (n)
+#endif
+
+#if ! HAVE_OPENSSL_SHA1
+
+/* This array contains the bytes used to pad the buffer to the next
+   64-byte boundary.  (RFC 1321, 3.1: Step 1)  */
+static const unsigned char fillbuf[64] = { 0x80, 0 /* , 0, 0, ...  */ };
+
+
+/* Take a pointer to a 160 bit block of data (five 32 bit ints) and
+   initialize it to the start constants of the SHA1 algorithm.  This
+   must be called before using hash in the call to sha1_hash.  */
+void
+sha1_init_ctx (struct sha1_ctx *ctx)
+{
+  ctx->A = 0x67452301;
+  ctx->B = 0xefcdab89;
+  ctx->C = 0x98badcfe;
+  ctx->D = 0x10325476;
+  ctx->E = 0xc3d2e1f0;
+
+  ctx->total[0] = ctx->total[1] = 0;
+  ctx->buflen = 0;
+}
+
+/* Copy the 4 byte value from v into the memory location pointed to by *cp,
+   If your architecture allows unaligned access this is equivalent to
+   * (uint32_t *) cp = v  */
+static void
+set_uint32 (char *cp, uint32_t v)
+{
+  memcpy (cp, &v, sizeof v);
+}
+
+/* Put result from CTX in first 20 bytes following RESBUF.  The result
+   must be in little endian byte order.  */
+void *
+sha1_read_ctx (const struct sha1_ctx *ctx, void *resbuf)
+{
+  char *r = resbuf;
+  set_uint32 (r + 0 * sizeof ctx->A, SWAP (ctx->A));
+  set_uint32 (r + 1 * sizeof ctx->B, SWAP (ctx->B));
+  set_uint32 (r + 2 * sizeof ctx->C, SWAP (ctx->C));
+  set_uint32 (r + 3 * sizeof ctx->D, SWAP (ctx->D));
+  set_uint32 (r + 4 * sizeof ctx->E, SWAP (ctx->E));
+
+  return resbuf;
+}
+
+/* Process the remaining bytes in the internal buffer and the usual
+   prolog according to the standard and write the result to RESBUF.  */
+void *
+sha1_finish_ctx (struct sha1_ctx *ctx, void *resbuf)
+{
+  /* Take yet unprocessed bytes into account.  */
+  uint32_t bytes = ctx->buflen;
+  size_t size = (bytes < 56) ? 64 / 4 : 64 * 2 / 4;
+
+  /* Now count remaining bytes.  */
+  ctx->total[0] += bytes;
+  if (ctx->total[0] < bytes)
+    ++ctx->total[1];
+
+  /* Put the 64-bit file length in *bits* at the end of the buffer.  */
+  ctx->buffer[size - 2] = SWAP ((ctx->total[1] << 3) | (ctx->total[0] >> 29));
+  ctx->buffer[size - 1] = SWAP (ctx->total[0] << 3);
+
+  memcpy (&((char *) ctx->buffer)[bytes], fillbuf, (size - 2) * 4 - bytes);
+
+  /* Process last bytes.  */
+  sha1_process_block (ctx->buffer, size * 4, ctx);
+
+  return sha1_read_ctx (ctx, resbuf);
+}
+
+/* Compute SHA1 message digest for LEN bytes beginning at BUFFER.  The
+   result is always in little endian byte order, so that a byte-wise
+   output yields to the wanted ASCII representation of the message
+   digest.  */
+void *
+sha1_buffer (const char *buffer, size_t len, void *resblock)
+{
+  struct sha1_ctx ctx;
+
+  /* Initialize the computation context.  */
+  sha1_init_ctx (&ctx);
+
+  /* Process whole buffer but last len % 64 bytes.  */
+  sha1_process_bytes (buffer, len, &ctx);
+
+  /* Put result in desired memory area.  */
+  return sha1_finish_ctx (&ctx, resblock);
+}
+
+void
+sha1_process_bytes (const void *buffer, size_t len, struct sha1_ctx *ctx)
+{
+  /* When we already have some bits in our internal buffer concatenate
+     both inputs first.  */
+  if (ctx->buflen != 0)
+    {
+      size_t left_over = ctx->buflen;
+      size_t add = 128 - left_over > len ? len : 128 - left_over;
+
+      memcpy (&((char *) ctx->buffer)[left_over], buffer, add);
+      ctx->buflen += add;
+
+      if (ctx->buflen > 64)
+        {
+          sha1_process_block (ctx->buffer, ctx->buflen & ~63, ctx);
+
+          ctx->buflen &= 63;
+          /* The regions in the following copy operation cannot overlap,
+             because ctx->buflen < 64 ≤ (left_over + add) & ~63.  */
+          memcpy (ctx->buffer,
+                  &((char *) ctx->buffer)[(left_over + add) & ~63],
+                  ctx->buflen);
+        }
+
+      buffer = (const char *) buffer + add;
+      len -= add;
+    }
+
+  /* Process available complete blocks.  */
+  if (len >= 64)
+    {
+#if !(_STRING_ARCH_unaligned || _STRING_INLINE_unaligned)
+# define UNALIGNED_P(p) ((uintptr_t) (p) % alignof (uint32_t) != 0)
+      if (UNALIGNED_P (buffer))
+        while (len > 64)
+          {
+            sha1_process_block (memcpy (ctx->buffer, buffer, 64), 64, ctx);
+            buffer = (const char *) buffer + 64;
+            len -= 64;
+          }
+      else
+#endif
+        {
+          sha1_process_block (buffer, len & ~63, ctx);
+          buffer = (const char *) buffer + (len & ~63);
+          len &= 63;
+        }
+    }
+
+  /* Move remaining bytes in internal buffer.  */
+  if (len > 0)
+    {
+      size_t left_over = ctx->buflen;
+
+      memcpy (&((char *) ctx->buffer)[left_over], buffer, len);
+      left_over += len;
+      if (left_over >= 64)
+        {
+          sha1_process_block (ctx->buffer, 64, ctx);
+          left_over -= 64;
+          /* The regions in the following copy operation cannot overlap,
+             because left_over ≤ 64.  */
+          memcpy (ctx->buffer, &ctx->buffer[16], left_over);
+        }
+      ctx->buflen = left_over;
+    }
+}
+
+/* --- Code below is the primary difference between md5.c and sha1.c --- */
+
+/* SHA1 round constants */
+#define K1 0x5a827999
+#define K2 0x6ed9eba1
+#define K3 0x8f1bbcdc
+#define K4 0xca62c1d6
+
+/* Round functions.  Note that F2 is the same as F4.  */
+#define F1(B,C,D) ( D ^ ( B & ( C ^ D ) ) )
+#define F2(B,C,D) (B ^ C ^ D)
+#define F3(B,C,D) ( ( B & C ) | ( D & ( B | C ) ) )
+#define F4(B,C,D) (B ^ C ^ D)
+
+/* Process LEN bytes of BUFFER, accumulating context into CTX.
+   It is assumed that LEN % 64 == 0.
+   Most of this code comes from GnuPG's cipher/sha1.c.  */
+
+void
+sha1_process_block (const void *buffer, size_t len, struct sha1_ctx *ctx)
+{
+  const uint32_t *words = buffer;
+  size_t nwords = len / sizeof (uint32_t);
+  const uint32_t *endp = words + nwords;
+  uint32_t x[16];
+  uint32_t a = ctx->A;
+  uint32_t b = ctx->B;
+  uint32_t c = ctx->C;
+  uint32_t d = ctx->D;
+  uint32_t e = ctx->E;
+  uint32_t lolen = len;
+
+  /* First increment the byte count.  RFC 1321 specifies the possible
+     length of the file up to 2^64 bits.  Here we only compute the
+     number of bytes.  Do a double word increment.  */
+  ctx->total[0] += lolen;
+  ctx->total[1] += (len >> 31 >> 1) + (ctx->total[0] < lolen);
+
+#define rol(x, n) (((x) << (n)) | ((uint32_t) (x) >> (32 - (n))))
+
+#define M(I) ( tm =   x[I&0x0f] ^ x[(I-14)&0x0f] \
+                    ^ x[(I-8)&0x0f] ^ x[(I-3)&0x0f] \
+               , (x[I&0x0f] = rol(tm, 1)) )
+
+#define R(A,B,C,D,E,F,K,M)  do { E += rol( A, 5 )     \
+                                      + F( B, C, D )  \
+                                      + K             \
+                                      + M;            \
+                                 B = rol( B, 30 );    \
+                               } while(0)
+
+  while (words < endp)
+    {
+      uint32_t tm;
+      int t;
+      for (t = 0; t < 16; t++)
+        {
+          x[t] = SWAP (*words);
+          words++;
+        }
+
+      R( a, b, c, d, e, F1, K1, x[ 0] );
+      R( e, a, b, c, d, F1, K1, x[ 1] );
+      R( d, e, a, b, c, F1, K1, x[ 2] );
+      R( c, d, e, a, b, F1, K1, x[ 3] );
+      R( b, c, d, e, a, F1, K1, x[ 4] );
+      R( a, b, c, d, e, F1, K1, x[ 5] );
+      R( e, a, b, c, d, F1, K1, x[ 6] );
+      R( d, e, a, b, c, F1, K1, x[ 7] );
+      R( c, d, e, a, b, F1, K1, x[ 8] );
+      R( b, c, d, e, a, F1, K1, x[ 9] );
+      R( a, b, c, d, e, F1, K1, x[10] );
+      R( e, a, b, c, d, F1, K1, x[11] );
+      R( d, e, a, b, c, F1, K1, x[12] );
+      R( c, d, e, a, b, F1, K1, x[13] );
+      R( b, c, d, e, a, F1, K1, x[14] );
+      R( a, b, c, d, e, F1, K1, x[15] );
+      R( e, a, b, c, d, F1, K1, M(16) );
+      R( d, e, a, b, c, F1, K1, M(17) );
+      R( c, d, e, a, b, F1, K1, M(18) );
+      R( b, c, d, e, a, F1, K1, M(19) );
+      R( a, b, c, d, e, F2, K2, M(20) );
+      R( e, a, b, c, d, F2, K2, M(21) );
+      R( d, e, a, b, c, F2, K2, M(22) );
+      R( c, d, e, a, b, F2, K2, M(23) );
+      R( b, c, d, e, a, F2, K2, M(24) );
+      R( a, b, c, d, e, F2, K2, M(25) );
+      R( e, a, b, c, d, F2, K2, M(26) );
+      R( d, e, a, b, c, F2, K2, M(27) );
+      R( c, d, e, a, b, F2, K2, M(28) );
+      R( b, c, d, e, a, F2, K2, M(29) );
+      R( a, b, c, d, e, F2, K2, M(30) );
+      R( e, a, b, c, d, F2, K2, M(31) );
+      R( d, e, a, b, c, F2, K2, M(32) );
+      R( c, d, e, a, b, F2, K2, M(33) );
+      R( b, c, d, e, a, F2, K2, M(34) );
+      R( a, b, c, d, e, F2, K2, M(35) );
+      R( e, a, b, c, d, F2, K2, M(36) );
+      R( d, e, a, b, c, F2, K2, M(37) );
+      R( c, d, e, a, b, F2, K2, M(38) );
+      R( b, c, d, e, a, F2, K2, M(39) );
+      R( a, b, c, d, e, F3, K3, M(40) );
+      R( e, a, b, c, d, F3, K3, M(41) );
+      R( d, e, a, b, c, F3, K3, M(42) );
+      R( c, d, e, a, b, F3, K3, M(43) );
+      R( b, c, d, e, a, F3, K3, M(44) );
+      R( a, b, c, d, e, F3, K3, M(45) );
+      R( e, a, b, c, d, F3, K3, M(46) );
+      R( d, e, a, b, c, F3, K3, M(47) );
+      R( c, d, e, a, b, F3, K3, M(48) );
+      R( b, c, d, e, a, F3, K3, M(49) );
+      R( a, b, c, d, e, F3, K3, M(50) );
+      R( e, a, b, c, d, F3, K3, M(51) );
+      R( d, e, a, b, c, F3, K3, M(52) );
+      R( c, d, e, a, b, F3, K3, M(53) );
+      R( b, c, d, e, a, F3, K3, M(54) );
+      R( a, b, c, d, e, F3, K3, M(55) );
+      R( e, a, b, c, d, F3, K3, M(56) );
+      R( d, e, a, b, c, F3, K3, M(57) );
+      R( c, d, e, a, b, F3, K3, M(58) );
+      R( b, c, d, e, a, F3, K3, M(59) );
+      R( a, b, c, d, e, F4, K4, M(60) );
+      R( e, a, b, c, d, F4, K4, M(61) );
+      R( d, e, a, b, c, F4, K4, M(62) );
+      R( c, d, e, a, b, F4, K4, M(63) );
+      R( b, c, d, e, a, F4, K4, M(64) );
+      R( a, b, c, d, e, F4, K4, M(65) );
+      R( e, a, b, c, d, F4, K4, M(66) );
+      R( d, e, a, b, c, F4, K4, M(67) );
+      R( c, d, e, a, b, F4, K4, M(68) );
+      R( b, c, d, e, a, F4, K4, M(69) );
+      R( a, b, c, d, e, F4, K4, M(70) );
+      R( e, a, b, c, d, F4, K4, M(71) );
+      R( d, e, a, b, c, F4, K4, M(72) );
+      R( c, d, e, a, b, F4, K4, M(73) );
+      R( b, c, d, e, a, F4, K4, M(74) );
+      R( a, b, c, d, e, F4, K4, M(75) );
+      R( e, a, b, c, d, F4, K4, M(76) );
+      R( d, e, a, b, c, F4, K4, M(77) );
+      R( c, d, e, a, b, F4, K4, M(78) );
+      R( b, c, d, e, a, F4, K4, M(79) );
+
+      a = ctx->A += a;
+      b = ctx->B += b;
+      c = ctx->C += c;
+      d = ctx->D += d;
+      e = ctx->E += e;
+    }
+}
+
+#endif
+
+/*
+ * Hey Emacs!
+ * Local Variables:
+ * coding: utf-8
+ * End:
+ */

--- a/.devcontainer/src/sha1.h
+++ b/.devcontainer/src/sha1.h
@@ -1,0 +1,146 @@
+/* Declarations of functions and data types used for SHA1 sum
+   library functions.
+   Copyright (C) 2000-2001, 2003, 2005-2006, 2008-2023 Free Software
+   Foundation, Inc.
+
+   This file is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   This file is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+#ifndef SHA1_H
+# define SHA1_H 1
+
+#if 0
+/* This file uses HAVE_OPENSSL_SHA1.  */
+# if !_GL_CONFIG_H_INCLUDED
+#  error "Please include config.h first."
+# endif
+#endif
+
+# include <stdio.h>
+# include <stdint.h>
+
+/*
+ * origin https://github.com/coreutils/gnulib/blob/master/lib/sha1.h
+ * the below is needed to compile successfully.
+ * also the above !_GL_CONFIG_H_INCLUDED check is skipped.
+ */
+# include <stdalign.h>
+#define HAVE_OPENSSL_SHA1 0
+#define _STRING_ARCH_unaligned	1
+#define _STRING_INLINE_unaligned 0
+
+# if HAVE_OPENSSL_SHA1
+#  ifndef OPENSSL_API_COMPAT
+#   define OPENSSL_API_COMPAT 0x10101000L /* FIXME: Use OpenSSL 1.1+ API.  */
+#  endif
+/* If <openssl/macros.h> would give a compile-time error, don't use OpenSSL.  */
+#  include <openssl/opensslv.h>
+#  if OPENSSL_VERSION_MAJOR >= 3
+#   include <openssl/configuration.h>
+#   if (OPENSSL_CONFIGURED_API \
+        < (OPENSSL_API_COMPAT < 0x900000L ? OPENSSL_API_COMPAT : \
+           ((OPENSSL_API_COMPAT >> 28) & 0xF) * 10000 \
+           + ((OPENSSL_API_COMPAT >> 20) & 0xFF) * 100 \
+           + ((OPENSSL_API_COMPAT >> 12) & 0xFF)))
+#    undef HAVE_OPENSSL_SHA1
+#   endif
+#  endif
+#  if HAVE_OPENSSL_SHA1
+#   include <openssl/sha.h>
+#  endif
+# endif
+
+# ifdef __cplusplus
+extern "C" {
+# endif
+
+# define SHA1_DIGEST_SIZE 20
+
+# if HAVE_OPENSSL_SHA1
+#  define GL_OPENSSL_NAME 1
+#  include "gl_openssl.h"
+# else
+/* Structure to save state of computation between the single steps.  */
+struct sha1_ctx
+{
+  uint32_t A;
+  uint32_t B;
+  uint32_t C;
+  uint32_t D;
+  uint32_t E;
+
+  uint32_t total[2];
+  uint32_t buflen;     /* ≥ 0, ≤ 128 */
+  uint32_t buffer[32]; /* 128 bytes; the first buflen bytes are in use */
+};
+
+/* Initialize structure containing state of computation. */
+extern void sha1_init_ctx (struct sha1_ctx *ctx);
+
+/* Starting with the result of former calls of this function (or the
+   initialization function update the context for the next LEN bytes
+   starting at BUFFER.
+   It is necessary that LEN is a multiple of 64!!! */
+extern void sha1_process_block (const void *buffer, size_t len,
+                                struct sha1_ctx *ctx);
+
+/* Starting with the result of former calls of this function (or the
+   initialization function update the context for the next LEN bytes
+   starting at BUFFER.
+   It is NOT required that LEN is a multiple of 64.  */
+extern void sha1_process_bytes (const void *buffer, size_t len,
+                                struct sha1_ctx *ctx);
+
+/* Process the remaining bytes in the buffer and put result from CTX
+   in first 20 bytes following RESBUF.  The result is always in little
+   endian byte order, so that a byte-wise output yields to the wanted
+   ASCII representation of the message digest.  */
+extern void *sha1_finish_ctx (struct sha1_ctx *ctx, void *restrict resbuf);
+
+
+/* Put result from CTX in first 20 bytes following RESBUF.  The result is
+   always in little endian byte order, so that a byte-wise output yields
+   to the wanted ASCII representation of the message digest.  */
+extern void *sha1_read_ctx (const struct sha1_ctx *ctx, void *restrict resbuf);
+
+
+/* Compute SHA1 message digest for LEN bytes beginning at BUFFER.  The
+   result is always in little endian byte order, so that a byte-wise
+   output yields to the wanted ASCII representation of the message
+   digest.  */
+extern void *sha1_buffer (const char *buffer, size_t len,
+                          void *restrict resblock);
+
+# endif
+
+/* Compute SHA1 message digest for bytes read from STREAM.
+   STREAM is an open file stream.  Regular files are handled more efficiently.
+   The contents of STREAM from its current position to its end will be read.
+   The case that the last operation on STREAM was an 'ungetc' is not supported.
+   The resulting message digest number will be written into the 20 bytes
+   beginning at RESBLOCK.  */
+extern int sha1_stream (FILE *stream, void *resblock);
+
+
+# ifdef __cplusplus
+}
+# endif
+
+#endif
+
+/*
+ * Hey Emacs!
+ * Local Variables:
+ * coding: utf-8
+ * End:
+ */

--- a/.devcontainer/src/sha256.c
+++ b/.devcontainer/src/sha256.c
@@ -1,0 +1,432 @@
+/* sha256.c - Functions to compute SHA256 and SHA224 message digest of files or
+   memory blocks according to the NIST specification FIPS-180-2.
+
+   Copyright (C) 2005-2006, 2008-2023 Free Software Foundation, Inc.
+
+   This file is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   This file is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+/* Written by David Madore, considerably copypasting from
+   Scott G. Miller's sha1.c
+*/
+
+#include <config.h>
+#include "sha256.h"
+
+/* Specification.  */
+#if HAVE_OPENSSL_SHA256
+# define GL_OPENSSL_INLINE _GL_EXTERN_INLINE
+#endif
+
+#include <stdint.h>
+#include <string.h>
+
+#include <byteswap.h>
+#ifdef WORDS_BIGENDIAN
+# define SWAP(n) (n)
+#else
+# define SWAP(n) bswap_32 (n)
+#endif
+
+#if ! HAVE_OPENSSL_SHA256
+
+/* This array contains the bytes used to pad the buffer to the next
+   64-byte boundary.  */
+static const unsigned char fillbuf[64] = { 0x80, 0 /* , 0, 0, ...  */ };
+
+
+/*
+  Takes a pointer to a 256 bit block of data (eight 32 bit ints) and
+  initializes it to the start constants of the SHA256 algorithm.  This
+  must be called before using hash in the call to sha256_hash
+*/
+void
+sha256_init_ctx (struct sha256_ctx *ctx)
+{
+  ctx->state[0] = 0x6a09e667UL;
+  ctx->state[1] = 0xbb67ae85UL;
+  ctx->state[2] = 0x3c6ef372UL;
+  ctx->state[3] = 0xa54ff53aUL;
+  ctx->state[4] = 0x510e527fUL;
+  ctx->state[5] = 0x9b05688cUL;
+  ctx->state[6] = 0x1f83d9abUL;
+  ctx->state[7] = 0x5be0cd19UL;
+
+  ctx->total[0] = ctx->total[1] = 0;
+  ctx->buflen = 0;
+}
+
+void
+sha224_init_ctx (struct sha256_ctx *ctx)
+{
+  ctx->state[0] = 0xc1059ed8UL;
+  ctx->state[1] = 0x367cd507UL;
+  ctx->state[2] = 0x3070dd17UL;
+  ctx->state[3] = 0xf70e5939UL;
+  ctx->state[4] = 0xffc00b31UL;
+  ctx->state[5] = 0x68581511UL;
+  ctx->state[6] = 0x64f98fa7UL;
+  ctx->state[7] = 0xbefa4fa4UL;
+
+  ctx->total[0] = ctx->total[1] = 0;
+  ctx->buflen = 0;
+}
+
+/* Copy the value from v into the memory location pointed to by *CP,
+   If your architecture allows unaligned access, this is equivalent to
+   * (__typeof__ (v) *) cp = v  */
+static void
+set_uint32 (char *cp, uint32_t v)
+{
+  memcpy (cp, &v, sizeof v);
+}
+
+/* Put result from CTX in first 32 bytes following RESBUF.
+   The result must be in little endian byte order.  */
+void *
+sha256_read_ctx (const struct sha256_ctx *ctx, void *resbuf)
+{
+  int i;
+  char *r = resbuf;
+
+  for (i = 0; i < 8; i++)
+    set_uint32 (r + i * sizeof ctx->state[0], SWAP (ctx->state[i]));
+
+  return resbuf;
+}
+
+void *
+sha224_read_ctx (const struct sha256_ctx *ctx, void *resbuf)
+{
+  int i;
+  char *r = resbuf;
+
+  for (i = 0; i < 7; i++)
+    set_uint32 (r + i * sizeof ctx->state[0], SWAP (ctx->state[i]));
+
+  return resbuf;
+}
+
+/* Process the remaining bytes in the internal buffer and the usual
+   prolog according to the standard and write the result to RESBUF.  */
+static void
+sha256_conclude_ctx (struct sha256_ctx *ctx)
+{
+  /* Take yet unprocessed bytes into account.  */
+  size_t bytes = ctx->buflen;
+  size_t size = (bytes < 56) ? 64 / 4 : 64 * 2 / 4;
+
+  /* Now count remaining bytes.  */
+  ctx->total[0] += bytes;
+  if (ctx->total[0] < bytes)
+    ++ctx->total[1];
+
+  /* Put the 64-bit file length in *bits* at the end of the buffer.
+     Use set_uint32 rather than a simple assignment, to avoid risk of
+     unaligned access.  */
+  set_uint32 ((char *) &ctx->buffer[size - 2],
+              SWAP ((ctx->total[1] << 3) | (ctx->total[0] >> 29)));
+  set_uint32 ((char *) &ctx->buffer[size - 1],
+              SWAP (ctx->total[0] << 3));
+
+  memcpy (&((char *) ctx->buffer)[bytes], fillbuf, (size - 2) * 4 - bytes);
+
+  /* Process last bytes.  */
+  sha256_process_block (ctx->buffer, size * 4, ctx);
+}
+
+void *
+sha256_finish_ctx (struct sha256_ctx *ctx, void *resbuf)
+{
+  sha256_conclude_ctx (ctx);
+  return sha256_read_ctx (ctx, resbuf);
+}
+
+void *
+sha224_finish_ctx (struct sha256_ctx *ctx, void *resbuf)
+{
+  sha256_conclude_ctx (ctx);
+  return sha224_read_ctx (ctx, resbuf);
+}
+
+/* Compute SHA256 message digest for LEN bytes beginning at BUFFER.  The
+   result is always in little endian byte order, so that a byte-wise
+   output yields to the wanted ASCII representation of the message
+   digest.  */
+void *
+sha256_buffer (const char *buffer, size_t len, void *resblock)
+{
+  struct sha256_ctx ctx;
+
+  /* Initialize the computation context.  */
+  sha256_init_ctx (&ctx);
+
+  /* Process whole buffer but last len % 64 bytes.  */
+  sha256_process_bytes (buffer, len, &ctx);
+
+  /* Put result in desired memory area.  */
+  return sha256_finish_ctx (&ctx, resblock);
+}
+
+void *
+sha224_buffer (const char *buffer, size_t len, void *resblock)
+{
+  struct sha256_ctx ctx;
+
+  /* Initialize the computation context.  */
+  sha224_init_ctx (&ctx);
+
+  /* Process whole buffer but last len % 64 bytes.  */
+  sha256_process_bytes (buffer, len, &ctx);
+
+  /* Put result in desired memory area.  */
+  return sha224_finish_ctx (&ctx, resblock);
+}
+
+void
+sha256_process_bytes (const void *buffer, size_t len, struct sha256_ctx *ctx)
+{
+  /* When we already have some bits in our internal buffer concatenate
+     both inputs first.  */
+  if (ctx->buflen != 0)
+    {
+      size_t left_over = ctx->buflen;
+      size_t add = 128 - left_over > len ? len : 128 - left_over;
+
+      memcpy (&((char *) ctx->buffer)[left_over], buffer, add);
+      ctx->buflen += add;
+
+      if (ctx->buflen > 64)
+        {
+          sha256_process_block (ctx->buffer, ctx->buflen & ~63, ctx);
+
+          ctx->buflen &= 63;
+          /* The regions in the following copy operation cannot overlap,
+             because ctx->buflen < 64 ≤ (left_over + add) & ~63.  */
+          memcpy (ctx->buffer,
+                  &((char *) ctx->buffer)[(left_over + add) & ~63],
+                  ctx->buflen);
+        }
+
+      buffer = (const char *) buffer + add;
+      len -= add;
+    }
+
+  /* Process available complete blocks.  */
+  if (len >= 64)
+    {
+#if !(_STRING_ARCH_unaligned || _STRING_INLINE_unaligned)
+# define UNALIGNED_P(p) ((uintptr_t) (p) % alignof (uint32_t) != 0)
+      if (UNALIGNED_P (buffer))
+        while (len > 64)
+          {
+            sha256_process_block (memcpy (ctx->buffer, buffer, 64), 64, ctx);
+            buffer = (const char *) buffer + 64;
+            len -= 64;
+          }
+      else
+#endif
+        {
+          sha256_process_block (buffer, len & ~63, ctx);
+          buffer = (const char *) buffer + (len & ~63);
+          len &= 63;
+        }
+    }
+
+  /* Move remaining bytes in internal buffer.  */
+  if (len > 0)
+    {
+      size_t left_over = ctx->buflen;
+
+      memcpy (&((char *) ctx->buffer)[left_over], buffer, len);
+      left_over += len;
+      if (left_over >= 64)
+        {
+          sha256_process_block (ctx->buffer, 64, ctx);
+          left_over -= 64;
+          /* The regions in the following copy operation cannot overlap,
+             because left_over ≤ 64.  */
+          memcpy (ctx->buffer, &ctx->buffer[16], left_over);
+        }
+      ctx->buflen = left_over;
+    }
+}
+
+/* --- Code below is the primary difference between sha1.c and sha256.c --- */
+
+/* SHA256 round constants */
+#define K(I) sha256_round_constants[I]
+static const uint32_t sha256_round_constants[64] = {
+  0x428a2f98UL, 0x71374491UL, 0xb5c0fbcfUL, 0xe9b5dba5UL,
+  0x3956c25bUL, 0x59f111f1UL, 0x923f82a4UL, 0xab1c5ed5UL,
+  0xd807aa98UL, 0x12835b01UL, 0x243185beUL, 0x550c7dc3UL,
+  0x72be5d74UL, 0x80deb1feUL, 0x9bdc06a7UL, 0xc19bf174UL,
+  0xe49b69c1UL, 0xefbe4786UL, 0x0fc19dc6UL, 0x240ca1ccUL,
+  0x2de92c6fUL, 0x4a7484aaUL, 0x5cb0a9dcUL, 0x76f988daUL,
+  0x983e5152UL, 0xa831c66dUL, 0xb00327c8UL, 0xbf597fc7UL,
+  0xc6e00bf3UL, 0xd5a79147UL, 0x06ca6351UL, 0x14292967UL,
+  0x27b70a85UL, 0x2e1b2138UL, 0x4d2c6dfcUL, 0x53380d13UL,
+  0x650a7354UL, 0x766a0abbUL, 0x81c2c92eUL, 0x92722c85UL,
+  0xa2bfe8a1UL, 0xa81a664bUL, 0xc24b8b70UL, 0xc76c51a3UL,
+  0xd192e819UL, 0xd6990624UL, 0xf40e3585UL, 0x106aa070UL,
+  0x19a4c116UL, 0x1e376c08UL, 0x2748774cUL, 0x34b0bcb5UL,
+  0x391c0cb3UL, 0x4ed8aa4aUL, 0x5b9cca4fUL, 0x682e6ff3UL,
+  0x748f82eeUL, 0x78a5636fUL, 0x84c87814UL, 0x8cc70208UL,
+  0x90befffaUL, 0xa4506cebUL, 0xbef9a3f7UL, 0xc67178f2UL,
+};
+
+/* Round functions.  */
+#define F2(A,B,C) ( ( A & B ) | ( C & ( A | B ) ) )
+#define F1(E,F,G) ( G ^ ( E & ( F ^ G ) ) )
+
+/* Process LEN bytes of BUFFER, accumulating context into CTX.
+   It is assumed that LEN % 64 == 0.
+   Most of this code comes from GnuPG's cipher/sha1.c.  */
+
+void
+sha256_process_block (const void *buffer, size_t len, struct sha256_ctx *ctx)
+{
+  const uint32_t *words = buffer;
+  size_t nwords = len / sizeof (uint32_t);
+  const uint32_t *endp = words + nwords;
+  uint32_t x[16];
+  uint32_t a = ctx->state[0];
+  uint32_t b = ctx->state[1];
+  uint32_t c = ctx->state[2];
+  uint32_t d = ctx->state[3];
+  uint32_t e = ctx->state[4];
+  uint32_t f = ctx->state[5];
+  uint32_t g = ctx->state[6];
+  uint32_t h = ctx->state[7];
+  uint32_t lolen = len;
+
+  /* First increment the byte count.  FIPS PUB 180-2 specifies the possible
+     length of the file up to 2^64 bits.  Here we only compute the
+     number of bytes.  Do a double word increment.  */
+  ctx->total[0] += lolen;
+  ctx->total[1] += (len >> 31 >> 1) + (ctx->total[0] < lolen);
+
+#define rol(x, n) (((x) << (n)) | ((x) >> (32 - (n))))
+#define S0(x) (rol(x,25)^rol(x,14)^(x>>3))
+#define S1(x) (rol(x,15)^rol(x,13)^(x>>10))
+#define SS0(x) (rol(x,30)^rol(x,19)^rol(x,10))
+#define SS1(x) (rol(x,26)^rol(x,21)^rol(x,7))
+
+#define M(I) ( tm =   S1(x[(I-2)&0x0f]) + x[(I-7)&0x0f] \
+                    + S0(x[(I-15)&0x0f]) + x[I&0x0f]    \
+               , x[I&0x0f] = tm )
+
+#define R(A,B,C,D,E,F,G,H,K,M)  do { t0 = SS0(A) + F2(A,B,C); \
+                                     t1 = H + SS1(E)  \
+                                      + F1(E,F,G)     \
+                                      + K             \
+                                      + M;            \
+                                     D += t1;  H = t0 + t1; \
+                               } while(0)
+
+  while (words < endp)
+    {
+      uint32_t tm;
+      uint32_t t0, t1;
+      int t;
+      /* FIXME: see sha1.c for a better implementation.  */
+      for (t = 0; t < 16; t++)
+        {
+          x[t] = SWAP (*words);
+          words++;
+        }
+
+      R( a, b, c, d, e, f, g, h, K( 0), x[ 0] );
+      R( h, a, b, c, d, e, f, g, K( 1), x[ 1] );
+      R( g, h, a, b, c, d, e, f, K( 2), x[ 2] );
+      R( f, g, h, a, b, c, d, e, K( 3), x[ 3] );
+      R( e, f, g, h, a, b, c, d, K( 4), x[ 4] );
+      R( d, e, f, g, h, a, b, c, K( 5), x[ 5] );
+      R( c, d, e, f, g, h, a, b, K( 6), x[ 6] );
+      R( b, c, d, e, f, g, h, a, K( 7), x[ 7] );
+      R( a, b, c, d, e, f, g, h, K( 8), x[ 8] );
+      R( h, a, b, c, d, e, f, g, K( 9), x[ 9] );
+      R( g, h, a, b, c, d, e, f, K(10), x[10] );
+      R( f, g, h, a, b, c, d, e, K(11), x[11] );
+      R( e, f, g, h, a, b, c, d, K(12), x[12] );
+      R( d, e, f, g, h, a, b, c, K(13), x[13] );
+      R( c, d, e, f, g, h, a, b, K(14), x[14] );
+      R( b, c, d, e, f, g, h, a, K(15), x[15] );
+      R( a, b, c, d, e, f, g, h, K(16), M(16) );
+      R( h, a, b, c, d, e, f, g, K(17), M(17) );
+      R( g, h, a, b, c, d, e, f, K(18), M(18) );
+      R( f, g, h, a, b, c, d, e, K(19), M(19) );
+      R( e, f, g, h, a, b, c, d, K(20), M(20) );
+      R( d, e, f, g, h, a, b, c, K(21), M(21) );
+      R( c, d, e, f, g, h, a, b, K(22), M(22) );
+      R( b, c, d, e, f, g, h, a, K(23), M(23) );
+      R( a, b, c, d, e, f, g, h, K(24), M(24) );
+      R( h, a, b, c, d, e, f, g, K(25), M(25) );
+      R( g, h, a, b, c, d, e, f, K(26), M(26) );
+      R( f, g, h, a, b, c, d, e, K(27), M(27) );
+      R( e, f, g, h, a, b, c, d, K(28), M(28) );
+      R( d, e, f, g, h, a, b, c, K(29), M(29) );
+      R( c, d, e, f, g, h, a, b, K(30), M(30) );
+      R( b, c, d, e, f, g, h, a, K(31), M(31) );
+      R( a, b, c, d, e, f, g, h, K(32), M(32) );
+      R( h, a, b, c, d, e, f, g, K(33), M(33) );
+      R( g, h, a, b, c, d, e, f, K(34), M(34) );
+      R( f, g, h, a, b, c, d, e, K(35), M(35) );
+      R( e, f, g, h, a, b, c, d, K(36), M(36) );
+      R( d, e, f, g, h, a, b, c, K(37), M(37) );
+      R( c, d, e, f, g, h, a, b, K(38), M(38) );
+      R( b, c, d, e, f, g, h, a, K(39), M(39) );
+      R( a, b, c, d, e, f, g, h, K(40), M(40) );
+      R( h, a, b, c, d, e, f, g, K(41), M(41) );
+      R( g, h, a, b, c, d, e, f, K(42), M(42) );
+      R( f, g, h, a, b, c, d, e, K(43), M(43) );
+      R( e, f, g, h, a, b, c, d, K(44), M(44) );
+      R( d, e, f, g, h, a, b, c, K(45), M(45) );
+      R( c, d, e, f, g, h, a, b, K(46), M(46) );
+      R( b, c, d, e, f, g, h, a, K(47), M(47) );
+      R( a, b, c, d, e, f, g, h, K(48), M(48) );
+      R( h, a, b, c, d, e, f, g, K(49), M(49) );
+      R( g, h, a, b, c, d, e, f, K(50), M(50) );
+      R( f, g, h, a, b, c, d, e, K(51), M(51) );
+      R( e, f, g, h, a, b, c, d, K(52), M(52) );
+      R( d, e, f, g, h, a, b, c, K(53), M(53) );
+      R( c, d, e, f, g, h, a, b, K(54), M(54) );
+      R( b, c, d, e, f, g, h, a, K(55), M(55) );
+      R( a, b, c, d, e, f, g, h, K(56), M(56) );
+      R( h, a, b, c, d, e, f, g, K(57), M(57) );
+      R( g, h, a, b, c, d, e, f, K(58), M(58) );
+      R( f, g, h, a, b, c, d, e, K(59), M(59) );
+      R( e, f, g, h, a, b, c, d, K(60), M(60) );
+      R( d, e, f, g, h, a, b, c, K(61), M(61) );
+      R( c, d, e, f, g, h, a, b, K(62), M(62) );
+      R( b, c, d, e, f, g, h, a, K(63), M(63) );
+
+      a = ctx->state[0] += a;
+      b = ctx->state[1] += b;
+      c = ctx->state[2] += c;
+      d = ctx->state[3] += d;
+      e = ctx->state[4] += e;
+      f = ctx->state[5] += f;
+      g = ctx->state[6] += g;
+      h = ctx->state[7] += h;
+    }
+}
+
+#endif
+
+/*
+ * Hey Emacs!
+ * Local Variables:
+ * coding: utf-8
+ * End:
+ */

--- a/.devcontainer/src/sha256.h
+++ b/.devcontainer/src/sha256.h
@@ -1,0 +1,152 @@
+/* Declarations of functions and data types used for SHA256 and SHA224 sum
+   library functions.
+   Copyright (C) 2005-2006, 2008-2023 Free Software Foundation, Inc.
+
+   This file is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   This file is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+#ifndef SHA256_H
+# define SHA256_H 1
+
+#if 0
+/* This file uses HAVE_OPENSSL_SHA256.  */
+# if !_GL_CONFIG_H_INCLUDED
+#  error "Please include config.h first."
+# endif
+#endif
+
+# include <stdio.h>
+# include <stdint.h>
+
+/*
+ * origin https://github.com/coreutils/gnulib/blob/master/lib/sha256.h
+ * the below is needed to compile successfully.
+ * also the above !_GL_CONFIG_H_INCLUDED check is skipped.
+ */
+# include <stdalign.h>
+#define HAVE_OPENSSL_SHA256 0
+#define _STRING_ARCH_unaligned	1
+#define _STRING_INLINE_unaligned 0
+
+# if HAVE_OPENSSL_SHA256
+#  ifndef OPENSSL_API_COMPAT
+#   define OPENSSL_API_COMPAT 0x10101000L /* FIXME: Use OpenSSL 1.1+ API.  */
+#  endif
+/* If <openssl/macros.h> would give a compile-time error, don't use OpenSSL.  */
+#  include <openssl/opensslv.h>
+#  if OPENSSL_VERSION_MAJOR >= 3
+#   include <openssl/configuration.h>
+#   if (OPENSSL_CONFIGURED_API \
+        < (OPENSSL_API_COMPAT < 0x900000L ? OPENSSL_API_COMPAT : \
+           ((OPENSSL_API_COMPAT >> 28) & 0xF) * 10000 \
+           + ((OPENSSL_API_COMPAT >> 20) & 0xFF) * 100 \
+           + ((OPENSSL_API_COMPAT >> 12) & 0xFF)))
+#    undef HAVE_OPENSSL_SHA256
+#   endif
+#  endif
+#  if HAVE_OPENSSL_SHA256
+#   include <openssl/sha.h>
+#  endif
+# endif
+
+# ifdef __cplusplus
+extern "C" {
+# endif
+
+enum { SHA224_DIGEST_SIZE = 224 / 8 };
+enum { SHA256_DIGEST_SIZE = 256 / 8 };
+
+# if HAVE_OPENSSL_SHA256
+#  define GL_OPENSSL_NAME 224
+#  include "gl_openssl.h"
+#  define GL_OPENSSL_NAME 256
+#  include "gl_openssl.h"
+# else
+/* Structure to save state of computation between the single steps.  */
+struct sha256_ctx
+{
+  uint32_t state[8];
+
+  uint32_t total[2];
+  size_t buflen;       /* ≥ 0, ≤ 128 */
+  uint32_t buffer[32]; /* 128 bytes; the first buflen bytes are in use */
+};
+
+/* Initialize structure containing state of computation. */
+extern void sha256_init_ctx (struct sha256_ctx *ctx);
+extern void sha224_init_ctx (struct sha256_ctx *ctx);
+
+/* Starting with the result of former calls of this function (or the
+   initialization function update the context for the next LEN bytes
+   starting at BUFFER.
+   It is necessary that LEN is a multiple of 64!!! */
+extern void sha256_process_block (const void *buffer, size_t len,
+                                  struct sha256_ctx *ctx);
+
+/* Starting with the result of former calls of this function (or the
+   initialization function update the context for the next LEN bytes
+   starting at BUFFER.
+   It is NOT required that LEN is a multiple of 64.  */
+extern void sha256_process_bytes (const void *buffer, size_t len,
+                                  struct sha256_ctx *ctx);
+
+/* Process the remaining bytes in the buffer and put result from CTX
+   in first 32 (28) bytes following RESBUF.  The result is always in little
+   endian byte order, so that a byte-wise output yields to the wanted
+   ASCII representation of the message digest.  */
+extern void *sha256_finish_ctx (struct sha256_ctx *ctx, void *restrict resbuf);
+extern void *sha224_finish_ctx (struct sha256_ctx *ctx, void *restrict resbuf);
+
+
+/* Put result from CTX in first 32 (28) bytes following RESBUF.  The result is
+   always in little endian byte order, so that a byte-wise output yields
+   to the wanted ASCII representation of the message digest.  */
+extern void *sha256_read_ctx (const struct sha256_ctx *ctx,
+                              void *restrict resbuf);
+extern void *sha224_read_ctx (const struct sha256_ctx *ctx,
+                              void *restrict resbuf);
+
+
+/* Compute SHA256 (SHA224) message digest for LEN bytes beginning at BUFFER.
+   The result is always in little endian byte order, so that a byte-wise
+   output yields to the wanted ASCII representation of the message
+   digest.  */
+extern void *sha256_buffer (const char *buffer, size_t len,
+                            void *restrict resblock);
+extern void *sha224_buffer (const char *buffer, size_t len,
+                            void *restrict resblock);
+
+# endif
+
+/* Compute SHA256 (SHA224) message digest for bytes read from STREAM.
+   STREAM is an open file stream.  Regular files are handled more efficiently.
+   The contents of STREAM from its current position to its end will be read.
+   The case that the last operation on STREAM was an 'ungetc' is not supported.
+   The resulting message digest number will be written into the 32 (28) bytes
+   beginning at RESBLOCK.  */
+extern int sha256_stream (FILE *stream, void *resblock);
+extern int sha224_stream (FILE *stream, void *resblock);
+
+
+# ifdef __cplusplus
+}
+# endif
+
+#endif
+
+/*
+ * Hey Emacs!
+ * Local Variables:
+ * coding: utf-8
+ * End:
+ */

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,3 +34,4 @@ jobs:
       - name: Check
         run: |
           ls bomtrace2
+          ls bomtrace3

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 *.o
+src/*.so
+src/*.a
+src/*.o
 src/hello
+src/hello2
 bombash
 bomtrace
 bomtrace2
+bomtrace3

--- a/bin/bomtrace.conf
+++ b/bin/bomtrace.conf
@@ -2,6 +2,7 @@
 # Lines starting with '#' character or empty lines are ignored.
 # Invalid lines are also ignored.
 # The last key=value line must have newline at the end to take effect.
+
 hook_script_file=/tmp/bomsh_hook2.py
 hook_script_cmdopt=-vv -n > /dev/null 2>&1 < /dev/null
 # More programs to watch for golang packages on RedHat/Centos/AlmaLinux
@@ -14,10 +15,29 @@ hook_script_cmdopt=-vv -n > /dev/null 2>&1 < /dev/null
 # For Debian build of automatic embedding .bom section at your preferred build steps
 #hook_script_cmdopt=-vv -n --embed_bom_after_commands /usr/bin/objcopy,/usr/bin/strip > /dev/null 2>&1 < /dev/null
 shell_cmd_file=/tmp/bomsh_cmd
+
 logfile=/tmp/bomsh_hook_bomtrace_logfile
+#raw_logfile=/tmp/bomsh_hook_raw_logfile
+#tmpdir=/tmp
+
+# What hash algorithms to compute for artifacts.
+# SHA1 = 1, SHA256 = 2, SHA1 + SHA256 = 3, DEFAULT = 0, NO_HASH = negative value
+#hash_alg=3
+
+# How to generate the dependency file for C/C++ compilation.
+# 0 generates depfile with instrumentation, 1 generates with child process, and 2 not generating depfile
+#generate_depfile=0
+
+# Should we handle conftest/conftest.o/libconftest.a output files during ./configure step.
+# 0 is default, means we ignore them; change to 1 to handle them
+#handle_conftest=0
+
+# What additional syscalls to intercept. only EXECVE syscall is intercepted by default.
 #syscalls=openat,close
+
 # Whether to skip checking program access permission before recording the command. Default is 0 or False, set to 1 to skip the check.
 #skip_checking_prog_access=1
+
 # Whether to do strict/exact program path comparison when recording the command. Default is 0 or False, set to 1 to do strict path comparison.
 # The default of 0 provides better coverage of watched programs, while setting to 1 provides accurate control of watched programs.
 #strict_prog_path=1


### PR DESCRIPTION
This is the initial commit of Bomtrace version 3.
Performance has significantly improved with Bomtrace3. Bomtrace2 is a few times (2x to 5x) slower than the baseline run, while Bomtrace3 has only 10% or 20% runtime overhead.
This significant performance improvement is achieved by rewriting the bomsh_hook2.py Python script with C code, eliminating a lot of process context switches overhead, which is unnecessary actually. Also C code is obviously faster than Python code. :-)

This initial commit has only support for C/C++ compiler and some tools like ar/strip/eu-strip, etc.
More commits will follow to support all the tools supported by Bomtrace2/bomsh_hook2.py script.